### PR TITLE
chore: rush watch

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -175,6 +175,17 @@
       "ignoreMissingScript": true,
       "ignoreDependencyOrder": true,
       "allowWarningsInSuccessfulBuild": true
+    },
+    {
+      "name": "build:watch",
+      "commandKind": "bulk",
+      "summary": "Build projects and watch for changes",
+      "description": "For details, see the article \"Using watch mode\" on the Rush website: https://rushjs.io/",
+      // use incremental build logic (important)
+      "incremental": true,
+      "enableParallelism": true,
+      // Enable "watch mode"
+      "watchForChanges": true
     }
   ],
 

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -21,10 +21,10 @@
   ],
   "scripts": {
     "build": "stencil build --docs",
-    "build.watch": "stencil build --docs --watch",
+    "build:watch": "stencil build --docs",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
-    "test.watch": "stencil test --spec --e2e --watchAll",
+    "test:watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate",
     "eslint": "eslint src/**/*{.ts,.tsx}",
     "stylelint": "stylelint \"**/*.{css,scss}\" --cache --cache-location .cache/.stylelintcache --rd",

--- a/libraries/angular-design-system/package.json
+++ b/libraries/angular-design-system/package.json
@@ -12,6 +12,7 @@
     "prepublishOnly": "npm run build",
     "prebuild": "rimraf ./dist",
     "build": "ng-packagr",
+    "build:watch": "ng-packagr",
     "watch": "tsc --watch",
     "version": "npm run build"
   },

--- a/libraries/react-design-system/package.json
+++ b/libraries/react-design-system/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "npm run clean && npm run compile",
+    "build": "rimraf dist && tsc -p . && rollup -c rollup.config.js",
+    "build:watch": "tsc -p . && rollup -c rollup.config.js",
     "clean": "rimraf dist",
     "compile": "tsc -p . && rollup -c rollup.config.js"
   },

--- a/libraries/vue-design-system/package.json
+++ b/libraries/vue-design-system/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "npm run clean && npm run compile",
+    "build": "rimraf dist && tsc -p . && rollup -c rollup.config.js",
+    "build:watch": "tsc -p . && rollup -c rollup.config.js",
     "clean": "rimraf dist",
     "compile": "tsc -p . && rollup -c rollup.config.js"
   },


### PR DESCRIPTION
- rush build watch

para compilar la base de distintos frameworks para un widget:

- `rush build:watch -T @modyo/react-profile`
- `rush build:watch -T @modyo/vue-profile`
- `rush build:watch -T @modyo/angular-profile`

@efbarong @johannrp27 