### PR TITLE
chore: adjust hint theme counter

### DIFF
--- a/libraries/modyo-design-system/src/components/m-counter/m-counter.tsx
+++ b/libraries/modyo-design-system/src/components/m-counter/m-counter.tsx
@@ -271,7 +271,7 @@ export class MCounter {
           {this.hint && (
             <m-hint
               text={this.hint}
-              theme={this.theme === 'danger' || this.theme === 'tertiary' || this.theme === 'warning' ? this.theme : 'info'}
+              theme={this.state ? this.getTheme(this.state) : undefined}
               {...(this.hintIconStart && ({
                 iconStart: this.hintIconStart,
                 iconStartFamilyClass: this.hintIconStartFamilyClass,


### PR DESCRIPTION
Arregla el estilo del hint del counter:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/42986303/215126884-7c7e15eb-20ce-4282-9857-d9113a3db13e.png">
