### PR TITLE
feat: add external setupJest.js

### DIFF
--- a/libraries/dynamic-ui-react/.eslintrc
+++ b/libraries/dynamic-ui-react/.eslintrc
@@ -22,6 +22,18 @@
       }
     },
     {
+      "files": ["setupJest.js"],
+      "env": {
+        "jest": true
+      },
+      "rules": {
+        "import/no-extraneous-dependencies": [
+          "error",
+          { "devDependencies": true }
+        ]
+      }
+    },
+    {
       "files": ["src/**/*.ts", "src/**/*.tsx"],
       "parserOptions": {
         "project": ["./tsconfig.json"],

--- a/libraries/dynamic-ui-react/package.json
+++ b/libraries/dynamic-ui-react/package.json
@@ -65,7 +65,8 @@
   "types": "./dist/types/index.d.ts",
   "files": [
     "dist/",
-    "src/style"
+    "src/style",
+    "setupJest.js"
   ],
   "dependencies": {
     "@floating-ui/react": "^0.26.1",

--- a/libraries/dynamic-ui-react/setupJest.js
+++ b/libraries/dynamic-ui-react/setupJest.js
@@ -1,0 +1,16 @@
+jest.mock('react-content-loader', () => jest.fn());
+
+jest.mock('react-responsive-pagination', () => jest.fn());
+
+jest.mock('@react-input/mask', () => ({
+  InputMask: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (text) => text,
+    i18n: {
+      changeLanguage: () => new Promise(() => {}),
+    },
+  }),
+}));


### PR DESCRIPTION
closes https://modyohq.atlassian.net/browse/FRAMEWORK-73

and fixes Jest widget issues