### PR TITLE
style: button link underline only on :hover state

### DIFF
--- a/libraries/dynamic-ui-react/src/style/base/_buttons.scss
+++ b/libraries/dynamic-ui-react/src/style/base/_buttons.scss
@@ -177,8 +177,8 @@
 [class*="btn-link-"] {
   --#{$prefix}btn-text-decoration: var(--#{$prefix}link-decoration);
 
-  span {
-    text-decoration: underline;
+  &:hover {
+    --#{$prefix}btn-text-decoration: underline;
   }
 
   @if $enable-gradients {


### PR DESCRIPTION
Normal:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/c8c110c7-2104-4fc9-95ae-75c382f5e66d">

Hover:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/c38bc5f0-79c9-43a5-922c-68f4f3799c64">
