### PR TITLE
feat: update react version and peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "jest-environment-jsdom": "~29.7.0",
         "lint-staged": "^15.2.10",
         "postcss-cli": "~10.1.0",
-        "react": "~18.2.0",
+        "react": "~18.3.1",
         "react-dom": "~18.2.0",
         "react-hot-toast": "~2.4.1",
         "react-i18next": "~13.3.1",
@@ -94,7 +94,7 @@
         "node": ">=20.13.1"
       },
       "peerDependencies": {
-        "react": "~18.2.0",
+        "react": "~18.3.1",
         "react-dom": "~18.2.0",
         "react-hot-toast": "~2.4.1",
         "react-i18next": "~13.3.1",
@@ -15059,9 +15059,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "jest-environment-jsdom": "~29.7.0",
     "lint-staged": "^15.2.10",
     "postcss-cli": "~10.1.0",
-    "react": "~18.2.0",
+    "react": "~18.3.1",
     "react-dom": "~18.2.0",
     "react-hot-toast": "~2.4.1",
     "react-i18next": "~13.3.1",
@@ -163,7 +163,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "react": "~18.2.0",
+    "react": "~18.3.1",
     "react-dom": "~18.2.0",
     "react-hot-toast": "~2.4.1",
     "react-i18next": "~13.3.1",


### PR DESCRIPTION
This PR is required according to [React Docs](https://github.com/facebook/react/releases/tag/v19.0.0), they suggest do the upgrade to get warnings and deprecation API and make a smooth transition to V19.

Please check this out https://github.com/facebook/react/releases/tag/v19.0.0 and get a better understanding of new changes, tooling and deprecations.