### PR TITLE
fix(DInput): set icon size variables on sm and lg

### DIFF
--- a/src/components/DAlert/DAlert.spec.tsx
+++ b/src/components/DAlert/DAlert.spec.tsx
@@ -28,7 +28,7 @@ it('should render info alert', () => {
       >
         <i
           class="d-icon bi bi-info-circle alert-icon"
-          style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+          style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
         />
         <div
           class="alert-text"

--- a/src/components/DButtonIcon/DButtonIcon.spec.tsx
+++ b/src/components/DButtonIcon/DButtonIcon.spec.tsx
@@ -16,7 +16,7 @@ it('should render base icon button', () => {
       >
         <i
           class="d-icon bi bi-x-lg"
-          style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+          style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
         />
       </button>
     </div>

--- a/src/components/DChip/DChip.spec.tsx
+++ b/src/components/DChip/DChip.spec.tsx
@@ -27,7 +27,7 @@ it('should render badge', () => {
         >
           <i
             class="d-icon bi bi-x-lg"
-            style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+            style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
           />
         </button>
       </span>

--- a/src/components/DDatePicker/DDatePicker.spec.tsx
+++ b/src/components/DDatePicker/DDatePicker.spec.tsx
@@ -40,7 +40,7 @@ it('should render datepicker', () => {
             >
               <i
                 class="d-icon bi bi-calendar"
-                style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+                style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
               />
             </button>
           </div>

--- a/src/components/DIcon/DIcon.spec.tsx
+++ b/src/components/DIcon/DIcon.spec.tsx
@@ -12,7 +12,7 @@ it('should render my component', () => {
     <div>
       <i
         class="d-icon bi bi-heart"
-        style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+        style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
       />
     </div>
   `);

--- a/src/components/DIconBase/DIconBase.spec.tsx
+++ b/src/components/DIconBase/DIconBase.spec.tsx
@@ -12,7 +12,7 @@ it('should render my component', () => {
     <div>
       <i
         class="d-icon bi bi-heart"
-        style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+        style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
       />
     </div>
   `);

--- a/src/components/DIconBase/DIconBase.tsx
+++ b/src/components/DIconBase/DIconBase.tsx
@@ -30,11 +30,11 @@ export default function DIconBase(
     theme,
     style,
     className,
-    size = '1.5rem',
+    size,
     loading = false,
     loadingDuration = 1.8,
     hasCircle = false,
-    circleSize = `calc(var(--${PREFIX_BS}icon-component-size) * 1)`,
+    circleSize = `calc(var(--${PREFIX_BS}icon-size) * 1)`,
     color,
     backgroundColor,
     materialStyle = false,
@@ -75,8 +75,8 @@ export default function DIconBase(
   }, [circleSize, hasCircle]);
 
   const generateStyleVariables = useMemo<CustomStyles | CSSProperties>(() => ({
-    [`--${PREFIX_BS}icon-component-size`]: size,
     [`--${PREFIX_BS}icon-component-loading-duration`]: `${loadingDuration}s`,
+    ...size && { [`--${PREFIX_BS}icon-component-size`]: size },
     ...colorStyle,
     ...backgroundStyle,
     ...circleSizeStyle,

--- a/src/components/DInput/DInput.tsx
+++ b/src/components/DInput/DInput.tsx
@@ -146,7 +146,6 @@ function DInput(
       ref={inputRef}
       id={id}
       className={classNames('form-control', {
-        [`form-control-${size}`]: !!size,
         'is-invalid': invalid,
         'is-valid': valid,
       })}
@@ -170,7 +169,6 @@ function DInput(
     floatingLabel,
     valid,
     value,
-    size,
   ]);
 
   const labelComponent = useMemo(() => (
@@ -216,6 +214,7 @@ function DInput(
       {label && !floatingLabel && labelComponent}
       <div
         className={classNames({
+          [`input-group-${size}`]: !!size,
           'input-group': true,
           'has-validation': invalid || valid,
         })}

--- a/src/components/DInputCounter/DInputCounter.spec.tsx
+++ b/src/components/DInputCounter/DInputCounter.spec.tsx
@@ -35,7 +35,7 @@ it('should render base counter', () => {
         >
           <i
             class="d-icon bi bi-dash-square"
-            style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+            style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
           />
         </button>
         <input
@@ -53,7 +53,7 @@ it('should render base counter', () => {
         >
           <i
             class="d-icon bi bi-plus-square"
-            style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+            style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
           />
         </button>
       </div>

--- a/src/components/DInputPassword/DInputPassword.spec.tsx
+++ b/src/components/DInputPassword/DInputPassword.spec.tsx
@@ -45,7 +45,7 @@ it('should render my component', () => {
           >
             <i
               class="d-icon bi bi-eye-slash"
-              style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+              style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
             />
           </button>
         </div>

--- a/src/components/DInputSearch/DInputSearch.spec.tsx
+++ b/src/components/DInputSearch/DInputSearch.spec.tsx
@@ -43,7 +43,7 @@ it('should render my component', () => {
         >
           <i
             class="d-icon bi bi-search"
-            style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+            style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
           />
         </button>
       </div>

--- a/src/components/DSelect/DSelect.spec.tsx
+++ b/src/components/DSelect/DSelect.spec.tsx
@@ -91,7 +91,7 @@ it('should render my component', () => {
               >
                 <i
                   class="d-icon bi bi-chevron-down"
-                  style="--bs-icon-component-size: 1.5rem; --bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
+                  style="--bs-icon-component-loading-duration: 1.8s; --bs-icon-component-padding: 0;"
                 />
               </div>
             </div>

--- a/src/style/abstracts/variables/_forms.scss
+++ b/src/style/abstracts/variables/_forms.scss
@@ -79,6 +79,8 @@ $input-group-addon-border-color: transparent !default;
 // scss-docs-end input-group-variables
 
 // custom
+$input-group-sm-icon-size: $spacer-4 !default;
+$input-group-lg-icon-size: $spacer-7 !default;
 $form-text-padding-y: 0 !default;
 $form-text-padding-x: 0 !default;
 // end custom

--- a/src/style/base/_input-group.scss
+++ b/src/style/base/_input-group.scss
@@ -62,6 +62,18 @@
   --#{$prefix}input-disabled-bg: #{$input-disabled-bg};
   --#{$prefix}input-disabled-color: #{$input-disabled-color};
 
+  // input group icon sizes
+  --#{$prefix}input-group-sm-icon-size: #{$input-group-sm-icon-size};
+  --#{$prefix}input-group-lg-icon-size: #{$input-group-lg-icon-size};
+
+  &.input-group-sm .d-icon {
+    --#{$prefix}icon-component-size: var(--#{$prefix}input-group-sm-icon-size);
+  }
+
+  &.input-group-lg .d-icon {
+    --#{$prefix}icon-component-size: var(--#{$prefix}input-group-lg-icon-size);
+  }
+
   border: var(--#{$prefix}input-border-width) solid var(--#{$prefix}input-border-color);
   @include border-radius(var(--#{$prefix}input-border-radius), 0);
 

--- a/stories/components/DInput.stories.tsx
+++ b/stories/components/DInput.stories.tsx
@@ -278,7 +278,7 @@ export const Default: Story = {
     placeholder: 'Placeholder',
     labelIcon: undefined,
     type: 'text',
-    value: '',
+    value: undefined,
     hint: 'Assistive text',
   },
 };


### PR DESCRIPTION
SM 16px icon size
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ec05629b-ec44-4b95-8123-908245a5fa50" />

LG 28px icon size 
<img width="409" alt="image" src="https://github.com/user-attachments/assets/bcebb229-ad95-415a-a81a-22a30c43011a" />
