### PR TITLE
chore: disable automatic CI triggers for develop branch

### DIFF
--- a/.github/workflows/cdn-rc.yml
+++ b/.github/workflows/cdn-rc.yml
@@ -1,8 +1,6 @@
 name: Sync CDN rc
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,8 +1,6 @@
 name: Dev Publish
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch:
 
 concurrency:
   group: dev-publish


### PR DESCRIPTION
Remove automatic CI triggers for the develop branch in the workflows, allowing for manual execution instead.