### PR TITLE
fix: improve scrollbar handling and stabilize body scroll locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ dist
 dist-transpiled
 .jest-cache
 .developers
+
+AGENTS.md

--- a/src/hooks/useDisableBodyScrollEffect.ts
+++ b/src/hooks/useDisableBodyScrollEffect.ts
@@ -1,13 +1,48 @@
+/* eslint-disable no-lonely-if */
+
 import { useEffect } from 'react';
 
 export default function useDisableBodyScrollEffect(disable: boolean) {
   useEffect(() => {
-    if (disable) {
+    let observer: MutationObserver | undefined;
+    let timer: number | undefined;
+
+    const lock = () => {
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
       document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = '0';
-    } else {
+      document.body.style.paddingRight = `${Math.max(0, scrollbarWidth)}px`;
+    };
+
+    const unlock = () => {
       document.body.style.overflow = 'unset';
-      document.body.style.paddingRight = 'unset';
+      document.body.style.paddingRight = '0';
+    };
+
+    if (disable) {
+      lock();
+    } else {
+      // Wait until all portal elements are removed (exit animations done)
+      if (document.querySelector('.portal')) {
+        observer = new MutationObserver(() => {
+          if (!document.querySelector('.portal')) {
+            unlock();
+            observer?.disconnect();
+          }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        // Fallback in case observer misses changes
+        timer = window.setTimeout(() => {
+          unlock();
+          observer?.disconnect();
+        }, 3000);
+      } else {
+        unlock();
+      }
     }
+
+    return () => {
+      if (observer) observer.disconnect();
+      if (timer) window.clearTimeout(timer);
+    };
   }, [disable]);
 }

--- a/src/hooks/useDisableBodyScrollEffect.ts
+++ b/src/hooks/useDisableBodyScrollEffect.ts
@@ -8,14 +8,16 @@ export default function useDisableBodyScrollEffect(disable: boolean) {
     let timer: number | undefined;
 
     const lock = () => {
-      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      const { clientWidth } = document.documentElement;
+      const { innerWidth } = window;
+      const scrollbarWidth = clientWidth ? innerWidth - clientWidth : 0;
       document.body.style.overflow = 'hidden';
       document.body.style.paddingRight = `${Math.max(0, scrollbarWidth)}px`;
     };
 
     const unlock = () => {
       document.body.style.overflow = 'unset';
-      document.body.style.paddingRight = '0';
+      document.body.style.paddingRight = '0px';
     };
 
     if (disable) {


### PR DESCRIPTION
Enhance scrollbar width calculation for consistent padding and stabilize layout when locking body scroll with portals to prevent layout shifts and horizontal jumps. Add a fallback mechanism for observer failures.