### PR TITLE
fix: remove shadow utility in favor to use bootstrap setup with css vars

### DIFF
--- a/src/style/abstracts/_utilities.scss
+++ b/src/style/abstracts/_utilities.scss
@@ -38,18 +38,6 @@ $utilities: map-merge(
         )
       )
     ),
-    "shadow": map-merge(
-      map-get($utilities, "shadow"),
-      (
-        responsive: true,
-        values: (
-          null: var(--#{$prefix}box-shadow),
-          sm: var(--#{$prefix}box-shadow-sm),
-          lg: var(--#{$prefix}box-shadow-lg),
-          none: none
-        )
-      )
-    ),
     "text-opacity": map-merge(
       map-get($utilities, "text-opacity"),
       (


### PR DESCRIPTION
Remove override in favor to use bootstrap default shadow utility changed in 5.3.2

https://github.com/twbs/bootstrap/commit/c81a694ff3363c37b5ac8f8dbcb3f6ce90d350dd