### PR TITLE
feat: add props.json exporter for MCP Hub integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ CLAUDE.md
 
 dist
 dist-transpiled
+docs
 .jest-cache
 .developers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "playwright": "^1.58.2",
         "postcss-cli": "~10.1.0",
         "react": "~19.2.1",
+        "react-docgen-typescript": "^2.4.0",
         "react-dom": "~19.2.1",
         "react-hot-toast": "~2.6.0",
         "react-i18next": "~16.2.4",
@@ -4745,9 +4746,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4762,9 +4760,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4779,9 +4774,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4796,9 +4788,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4813,9 +4802,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4830,9 +4816,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4847,9 +4830,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4864,9 +4844,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4881,9 +4858,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4898,9 +4872,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4915,9 +4886,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4932,9 +4900,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4949,9 +4914,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6242,9 +6204,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6259,9 +6218,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6276,9 +6232,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6293,9 +6246,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6310,9 +6260,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6327,9 +6274,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6344,9 +6288,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6361,9 +6302,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "playwright": "^1.58.2",
     "postcss-cli": "~10.1.0",
     "react": "~19.2.1",
+    "react-docgen-typescript": "^2.4.0",
     "react-dom": "~19.2.1",
     "react-hot-toast": "~2.6.0",
     "react-i18next": "~16.2.4",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "clean": "rimraf dist-transpiled && rimraf dist",
     "compile": "tsc -p . && rollup -c rollup.config.mjs",
     "storybook": "storybook dev -p 6006",
-    "build:storybook": "storybook build --docs -o docs",
+    "build:storybook": "storybook build --docs -o docs && node scripts/generate-props.mjs",
     "eslint": "npm run eslint:src && npm run eslint:stories && npm run eslint:test",
     "eslint:src": "eslint 'src/**/*.ts' 'src/**/*.tsx' --ignore-pattern '**/*.spec.tsx'",
     "eslint:stories": "eslint stories/**/*.stories.tsx",

--- a/scripts/generate-props.mjs
+++ b/scripts/generate-props.mjs
@@ -104,13 +104,15 @@ for (const filePath of componentFiles) {
 
 // --- Output ---
 const OUTPUT_PATH = resolve(OUTPUT_DIR, 'props.json');
-writeFileSync(OUTPUT_PATH, JSON.stringify(results, null, 2));
+const output = JSON.stringify(results, null, 2);
+writeFileSync(OUTPUT_PATH, output);
 
-const sizeKB = (Buffer.byteLength(JSON.stringify(results)) / 1024).toFixed(1);
+const sizeKB = (Buffer.byteLength(output) / 1024).toFixed(1);
 const uniqueComponents = Object.keys(results).length;
 console.log(`\n✅ Generated docs/props.json`);
 console.log(`   Components: ${uniqueComponents} exported (from ${componentFiles.length} source files), ${failed} failed`);
 console.log(`   Size: ${sizeKB} KB`);
 if (failed > 0) {
-  console.log(`\n⚠️  ${failed} components failed — check warnings above`);
+  console.error(`\n❌ ${failed} components failed — check warnings above`);
+  process.exit(1);
 }

--- a/scripts/generate-props.mjs
+++ b/scripts/generate-props.mjs
@@ -63,7 +63,6 @@ const parser = docgen.withCustomConfig(TSCONFIG_PATH, {
 
 // --- Parsear ---
 const results = {};
-let parsed = 0;
 let failed = 0;
 
 for (const filePath of componentFiles) {
@@ -89,7 +88,6 @@ for (const filePath of componentFiles) {
           ])
         ),
       };
-      parsed++;
     }
   } catch (err) {
     const componentName = basename(filePath, '.tsx');

--- a/scripts/generate-props.mjs
+++ b/scripts/generate-props.mjs
@@ -1,0 +1,111 @@
+/**
+ * generate-props.mjs
+ *
+ * Genera docs/props.json con los props de todos los componentes Dynamic UI.
+ * Reutiliza la misma configuración de react-docgen-typescript que usa Storybook.
+ *
+ * Prerequisito: npm run build:storybook debe haber corrido antes (necesita docs/)
+ * Uso: node scripts/generate-props.mjs
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { resolve, dirname, basename } from 'path';
+import { fileURLToPath } from 'url';
+import * as docgen from 'react-docgen-typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// --- Validación ---
+const OUTPUT_DIR = resolve(ROOT, 'docs');
+if (!existsSync(OUTPUT_DIR)) {
+  console.error('❌ docs/ not found. Run `npm run build:storybook` first.');
+  process.exit(1);
+}
+
+const TSCONFIG_PATH = resolve(ROOT, 'tsconfig.json');
+if (!existsSync(TSCONFIG_PATH)) {
+  console.error('❌ tsconfig.json not found at project root.');
+  process.exit(1);
+}
+
+// --- Encontrar componentes fuente ---
+// Patrón: src/components/D*/D*.tsx (cada componente en su carpeta)
+const COMPONENTS_DIR = resolve(ROOT, 'src/components');
+
+const componentFiles = readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+  .filter(entry => entry.isDirectory() && entry.name.startsWith('D'))
+  .map(entry => {
+    // Archivo principal del componente: D{Name}/D{Name}.tsx
+    const mainFile = resolve(COMPONENTS_DIR, entry.name, `${entry.name}.tsx`);
+    return existsSync(mainFile) ? mainFile : null;
+  })
+  .filter(Boolean);
+
+if (componentFiles.length === 0) {
+  console.error('❌ No component files found in src/components/D*/D*.tsx');
+  process.exit(1);
+}
+
+console.log(`📦 Parsing props for ${componentFiles.length} components...`);
+
+// --- Parser con misma config que .storybook/main.ts ---
+const parser = docgen.withCustomConfig(TSCONFIG_PATH, {
+  shouldExtractLiteralValuesFromEnum: true,
+  // Misma propFilter que .storybook/main.ts:
+  propFilter: (prop) => {
+    if (prop.parent) {
+      return !/node_modules/.test(prop.parent.fileName);
+    }
+    return true;
+  },
+});
+
+// --- Parsear ---
+const results = {};
+let parsed = 0;
+let failed = 0;
+
+for (const filePath of componentFiles) {
+  try {
+    const docs = parser.parse(filePath);
+
+    for (const doc of docs) {
+      if (!doc.displayName) continue;
+
+      results[doc.displayName] = {
+        description: doc.description ?? '',
+        props: Object.fromEntries(
+          Object.entries(doc.props).map(([name, prop]) => [
+            name,
+            {
+              type: prop.type?.name === 'enum' && Array.isArray(prop.type?.value)
+                ? prop.type.value.map(v => v.value).join(' | ')
+                : prop.type?.name ?? 'unknown',
+              required: prop.required,
+              defaultValue: prop.defaultValue?.value ?? null,
+              description: prop.description ?? '',
+            }
+          ])
+        ),
+      };
+      parsed++;
+    }
+  } catch (err) {
+    const componentName = basename(filePath, '.tsx');
+    console.warn(`  ⚠️  Failed: ${componentName} — ${err.message}`);
+    failed++;
+  }
+}
+
+// --- Output ---
+const OUTPUT_PATH = resolve(OUTPUT_DIR, 'props.json');
+writeFileSync(OUTPUT_PATH, JSON.stringify(results, null, 2));
+
+const sizeKB = (Buffer.byteLength(JSON.stringify(results)) / 1024).toFixed(1);
+console.log(`\n✅ Generated docs/props.json`);
+console.log(`   Components: ${parsed} parsed, ${failed} failed`);
+console.log(`   Size: ${sizeKB} KB`);
+if (failed > 0) {
+  console.log(`\n⚠️  ${failed} components failed — check warnings above`);
+}

--- a/scripts/generate-props.mjs
+++ b/scripts/generate-props.mjs
@@ -35,6 +35,7 @@ const COMPONENTS_DIR = resolve(ROOT, 'src/components');
 
 const componentFiles = readdirSync(COMPONENTS_DIR, { withFileTypes: true })
   .filter(entry => entry.isDirectory() && entry.name.startsWith('D'))
+  .sort((a, b) => a.name.localeCompare(b.name))
   .map(entry => {
     // Archivo principal del componente: D{Name}/D{Name}.tsx
     const mainFile = resolve(COMPONENTS_DIR, entry.name, `${entry.name}.tsx`);
@@ -71,6 +72,10 @@ for (const filePath of componentFiles) {
 
     for (const doc of docs) {
       if (!doc.displayName) continue;
+
+      if (results[doc.displayName]) {
+        console.warn(`  ⚠️  Duplicate displayName: ${doc.displayName} (from ${basename(filePath, '.tsx')}, already seen) — overwriting`);
+      }
 
       results[doc.displayName] = {
         description: doc.description ?? '',

--- a/scripts/generate-props.mjs
+++ b/scripts/generate-props.mjs
@@ -8,7 +8,7 @@
  * Uso: node scripts/generate-props.mjs
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { writeFileSync, existsSync, readdirSync } from 'fs';
 import { resolve, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import * as docgen from 'react-docgen-typescript';
@@ -93,7 +93,8 @@ for (const filePath of componentFiles) {
     }
   } catch (err) {
     const componentName = basename(filePath, '.tsx');
-    console.warn(`  ⚠️  Failed: ${componentName} — ${err.message}`);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.warn(`  ⚠️  Failed: ${componentName} — ${errorMessage}`);
     failed++;
   }
 }
@@ -103,8 +104,9 @@ const OUTPUT_PATH = resolve(OUTPUT_DIR, 'props.json');
 writeFileSync(OUTPUT_PATH, JSON.stringify(results, null, 2));
 
 const sizeKB = (Buffer.byteLength(JSON.stringify(results)) / 1024).toFixed(1);
+const uniqueComponents = Object.keys(results).length;
 console.log(`\n✅ Generated docs/props.json`);
-console.log(`   Components: ${parsed} parsed, ${failed} failed`);
+console.log(`   Components: ${uniqueComponents} exported (from ${componentFiles.length} source files), ${failed} failed`);
 console.log(`   Size: ${sizeKB} KB`);
 if (failed > 0) {
   console.log(`\n⚠️  ${failed} components failed — check warnings above`);


### PR DESCRIPTION
## Resumen

  Agrega un script post-build que genera `docs/props.json` con los props extraídos
  de los componentes Dynamic UI usando `react-docgen-typescript` (misma config que
  ya usa Storybook en `.storybook/main.ts`).

  ## Motivación

  El MCP Hub necesita acceso a los props de componentes en tiempo real para generar
  widgets correctos sin depender de documentación manual. Este archivo se despliega
  automáticamente junto con Storybook en GitHub Pages.

  ## Cambios

  - **`scripts/generate-props.mjs`** — nuevo script que parsea los 49 archivos fuente
    en `src/components/D*/D*.tsx` y genera un JSON con tipos, valores por defecto,
    required y description de cada prop
  - **`package.json`** — agrega `&& node scripts/generate-props.mjs` al script
    `build:storybook` para que corra automáticamente
  - **`.gitignore`** — agrega `docs` (artefacto de build, se publica vía CI)

  ## Output

  - 51 componentes parseados, 0 fallos
  - ~88 KB
  - Valores de enums expandidos (ej: `"outline" | "link"`, no `"enum"`)
  - Se publica en `docs/latest/props.json` vía el workflow `storybook.yml` existente
    sin cambios al CI

  ## Ejemplo de output

  ```json
  {
    "DButton": {
      "props": {
        "variant": {
          "type": "undefined | \"outline\" | \"link\"",
          "required": false,
          "defaultValue": null
        }
      }
    }
  }