### PR TITLE
fix: add explicit NODE_AUTH_TOKEN to npm publish step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,4 +56,6 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Agrega `NODE_AUTH_TOKEN` explícito al paso de npm publish en release-please.yml.

Actualmente el token se inyecta de forma implícita como repo-level env var, lo que es frágil e inconsistente con `dev.yml` (que ya lo pasa explícitamente en línea 46). Este cambio lo hace explícito y robusto ante cambios de configuración del repo.