### PR TITLE
chore: pin all actions to SHA, upgrade to v6, add explicit permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/cdn-rc.yml
+++ b/.github/workflows/cdn-rc.yml
@@ -2,16 +2,19 @@ name: Sync CDN rc
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies
@@ -26,7 +29,7 @@ jobs:
       - name: Build packages
         run: npm run build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -3,16 +3,19 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies
@@ -27,7 +30,7 @@ jobs:
       - name: Build packages
         run: npm run build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,16 +6,19 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Lint and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -2,6 +2,11 @@ name: Dev Publish
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
   group: dev-publish
   cancel-in-progress: false
@@ -10,11 +15,11 @@ jobs:
   dev-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/
@@ -45,7 +50,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -56,8 +61,8 @@ jobs:
         run: npm run build:storybook
         env:
           STORYBOOK_DEV: "true"
-      - name: Deploy dev storybook 🚀
-        uses: JamesIves/github-pages-deploy-action@3.6.2
+      - name: Deploy dev storybook
+        uses: JamesIves/github-pages-deploy-action@e80c869f0057899fc2cd28819b5bbe9de890524a # 3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: docs

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,9 +3,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: dev-publish

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -10,12 +10,16 @@ on:
       synchronize
     ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   pr-labeler:
     name: Labeling Job
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v4
+      - uses: TimonVS/pr-labeler-action@8b99f404a073744885d8021d1de4e40c6eaf38e2 # v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml # optional, .github/pr-labeler.yml is the default value

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,4 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,19 +16,19 @@ jobs:
     name: Version and Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: node
           target-branch: master
           config-file: release-please-config.json
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # these if statements ensure that a publication only occurs when
         # a new release is created:
         if: ${{ steps.release.outputs.release_created }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/
@@ -56,4 +56,6 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -4,9 +4,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   storybook:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -3,16 +3,21 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   storybook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies
@@ -28,8 +33,8 @@ jobs:
         run: npm run build
       - name: Build storybook
         run: npm run build:storybook
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.6.2
+      - name: Deploy latest storybook
+        uses: JamesIves/github-pages-deploy-action@e80c869f0057899fc2cd28819b5bbe9de890524a # 3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: docs


### PR DESCRIPTION
## Motivación

  Reducir superficie de ataque en CI/CD tras revisión de supply chain security.
  Todos los workflows usaban tags mutables (@v4) sin permisos explícitos.

  ## Cambios

  ### SHA pinning
  - Todas las actions pineadas a commit SHA inmutable con comentario de versión
  - Dependabot configurado para actualizaciones semanales automáticas de SHAs

  ### Actualizaciones
  - `actions/checkout` v4 → v6.0.2
  - `actions/setup-node` v4 → v6.3.0
  - `aws-actions/configure-aws-credentials` v4 → v6.1.0
  - `googleapis/release-please-action` v4 → v4.4.0 (pin)
  - `JamesIves/github-pages-deploy-action` 3.6.2 → pin SHA (sin upgrade)
  - `TimonVS/pr-labeler-action` v4 → pin SHA (sin upgrade)

  ### Permisos mínimos (least privilege)
  - 6 workflows ahora declaran `permissions:` explícito
  - `release-please.yml` ya lo tenía — se agregó NODE_AUTH_TOKEN explícito al publish

  ## No incluido (requiere PRs separados)
  - **Reemplazar JamesIves → actions/deploy-pages**: pineado a SHA como mitigación temporal. Reemplazar requiere
  rediseñar la estrategia de subdirectorios (docs/latest/ + docs/dev/).
  Documentar arquitectura actual antes de abordar.
  - **Reemplazar TimonVS → actions/labeler**: pineado a SHA como mitigación temporal. Reemplazar requiere
  reescribir .github/labeler.yml de branch patterns a file path patterns.
  Bajo riesgo, alta simplicidad cuando se decida abordar.