### PR TITLE
docs(portal): documentar useDPortalContext y exponerlo en api.json

### DIFF
--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -62,9 +62,10 @@ function jsDocCommentToString(comment) {
   return ts.displayPartsToString(comment).trim();
 }
 
-/** Reads the JSDoc text attached directly to a node via ts.getJSDocCommentsAndTags. */
+/** Reads the main JSDoc description text attached to a node, excluding tag comments. */
 function getNodeJsDoc(node) {
   return ts.getJSDocCommentsAndTags(node)
+    .filter((d) => ts.isJSDoc(d))
     .map((d) => jsDocCommentToString(d.comment))
     .filter(Boolean)
     .join('\n')

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -88,7 +88,14 @@ function typeNodeText(typeNode, sourceFile) {
  * (the `required` flag on the parent field already captures optionality).
  * Recursion is capped at depth 3 to avoid expanding deep library internals.
  */
-function resolveTypeInfo(type, checker, locationNode, depth = 0) {
+/**
+ * @param {boolean} [expand=false] When true, always expand object types inline
+ *   even when they have a named alias (used for the top-level `types` section).
+ *   When false (default), a type with a user-defined alias symbol is emitted as
+ *   `{ type: "AliasName" }` instead of being expanded — this produces cleaner
+ *   references such as `CurrencyProps` instead of an anonymous `object` with fields.
+ */
+function resolveTypeInfo(type, checker, locationNode, depth = 0, expand = false) {
   if (depth > 3) return { type: checker.typeToString(type) };
 
   // Guard primitive types before getPropertiesOfType, which would otherwise
@@ -108,8 +115,24 @@ function resolveTypeInfo(type, checker, locationNode, depth = 0) {
       return { type: 'string', values: nonUndefined.map((t) => t.value) };
     }
     if (nonUndefined.length === 1) {
-      return resolveTypeInfo(nonUndefined[0], checker, locationNode, depth);
+      return resolveTypeInfo(nonUndefined[0], checker, locationNode, depth, expand);
     }
+    return { type: checker.typeToString(type) };
+  }
+
+  // Array types — emit `ElementType[]` rather than expanding all Array.prototype
+  // methods (push, pop, splice, sort, …) which are noise in documentation.
+  if (checker.isArrayType(type)) {
+    const [elemType] = checker.getTypeArguments(type) ?? [];
+    const elemStr = elemType ? checker.typeToString(elemType) : 'unknown';
+    return { type: `${elemStr}[]` };
+  }
+
+  // Named type aliases (e.g. CurrencyProps, BreakpointProps) — when expand is
+  // false, emit the alias name as a reference instead of expanding inline.
+  // This keeps prop definitions clean and avoids duplicating the type details
+  // that are already present in the `types` section of the API output.
+  if (!expand && type.aliasSymbol) {
     return { type: checker.typeToString(type) };
   }
 
@@ -123,6 +146,8 @@ function resolveTypeInfo(type, checker, locationNode, depth = 0) {
       const isOptional = !!(Number(prop.flags) & Number(ts.SymbolFlags.Optional));
       const desc = ts.displayPartsToString(prop.getDocumentationComment(checker)).trim();
       fields[prop.name] = {
+        // Nested fields within an explicitly expanded type never get further
+        // expand=true to avoid infinite recursion on self-referential types.
         ...resolveTypeInfo(propType, checker, locationNode, depth + 1),
         required: !isOptional,
         ...(desc ? { description: desc } : {}),
@@ -301,19 +326,32 @@ function extractFileDocs(relPath) {
             const symbolDoc = ts.displayPartsToString(
               prop.getDocumentationComment(checker),
             ).trim();
-            doc.returns[prop.name] = {
-              description: symbolDoc || innerJsDoc[prop.name] || '',
-              parameters: extractCallParams(prop, checker, node).map((p) => ({
-                ...p,
-                description:
-                  p.description
-                  || (innerParamDescriptions[prop.name] ?? {})[p.name]
-                  || '',
-              })),
-              returns: {
-                type: extractReturnTypeString(prop, checker, node),
-              },
-            };
+            const propType = checker.getTypeOfSymbolAtLocation(prop, node);
+            const propSigs = checker.getSignaturesOfType(propType, ts.SignatureKind.Call);
+            const description = symbolDoc || innerJsDoc[prop.name] || '';
+
+            if (propSigs.length > 0) {
+              // Function-typed return value — emit callable descriptor.
+              doc.returns[prop.name] = {
+                description,
+                parameters: extractCallParams(prop, checker, node).map((p) => ({
+                  ...p,
+                  description:
+                    p.description
+                    || (innerParamDescriptions[prop.name] ?? {})[p.name]
+                    || '',
+                })),
+                returns: {
+                  type: extractReturnTypeString(prop, checker, node),
+                },
+              };
+            } else {
+              // Non-callable return value (plain data property) — emit type info.
+              doc.returns[prop.name] = {
+                description,
+                ...resolveTypeInfo(propType, checker, node),
+              };
+            }
           });
         }
       }
@@ -397,7 +435,9 @@ function extractFileDocs(relPath) {
         const declType = checker.getTypeAtLocation(node.name);
         sharedTypes[node.name.text] = {
           description: nodeDescription,
-          ...resolveTypeInfo(declType, checker, node),
+          // expand=true: always expand fields in the types section even when
+          // the type has a named alias (e.g. CurrencyProps itself).
+          ...resolveTypeInfo(declType, checker, node, 0, true),
         };
       }
     }

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -87,8 +87,7 @@ function typeNodeText(typeNode, sourceFile) {
  * Union members that are `undefined` are stripped so optional properties stay clean
  * (the `required` flag on the parent field already captures optionality).
  * Recursion is capped at depth 3 to avoid expanding deep library internals.
- */
-/**
+ *
  * @param {boolean} [expand=false] When true, always expand object types inline
  *   even when they have a named alias (used for the top-level `types` section).
  *   When false (default), a type with a user-defined alias symbol is emitted as

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -38,10 +38,11 @@ if (!existsSync(TSCONFIG_PATH)) {
   process.exit(1);
 }
 
-// --- Public hook files to document (relative to project root) ---
+// --- Public hook/context files to document (relative to project root) ---
 const HOOK_FILES = [
   'src/components/DToastContainer/useDToast.tsx',
   'src/contexts/DPortalContext.tsx',
+  'src/contexts/DContext.tsx',
 ];
 
 // --- Load tsconfig ---
@@ -207,18 +208,16 @@ function buildSignature(hookName, parameters, returnKeys) {
 // --- Core extraction ---
 
 /**
- * Parses a hook source file and returns a structured API descriptor:
- * {
- *   source,        // relative file path
- *   description,   // hook JSDoc
- *   requires,      // prerequisite components/providers (@requires tags)
- *   signature,     // TypeScript-style function signature
- *   parameters,    // hook function parameters (usually empty for React hooks)
- *   returns,       // map of returned properties → their call signature
- *   types,         // exported type aliases with field descriptions
- * }
+ * Parses a source file and returns an array of API descriptor objects, one per
+ * exported hook (`use*`) or documented provider component found in the file.
+ *
+ * Each hook entry:
+ * { source, kind:'hook', description, requires, signature, parameters, returns, types }
+ *
+ * Each component entry:
+ * { source, kind:'component', description, requires, signature, props, types }
  */
-function extractHookDoc(relPath) {
+function extractFileDocs(relPath) {
   const filePath = resolve(ROOT, relPath);
   if (!existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
 
@@ -227,24 +226,27 @@ function extractHookDoc(relPath) {
   const sourceFile = program.getSourceFile(filePath);
   if (!sourceFile) throw new Error(`Could not load source file: ${filePath}`);
 
-  // hookName is derived from the file name as a fallback; overridden below when
-  // a named exported function whose name starts with "use" is found.
-  let hookName = relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
-  const doc = {
-    source: relPath,
-    description: '',
-    requires: [],
-    signature: '',
-    parameters: [],
-    returns: {},
-    types: {},
-  };
+  // Exported types with JSDoc — shared across all entries from this file.
+  const sharedTypes = {};
+
+  // Collected doc entries (one per exported hook or documented component).
+  const entries = [];
 
   /**
-   * Processes a function declaration node that is the hook entry point.
-   * Shared by both `export default function` and `export function useXxx`.
+   * Processes an exported hook function (`use*`) and pushes a hook entry.
    */
   function processHookNode(node, name) {
+    const doc = {
+      source: relPath,
+      kind: 'hook',
+      description: '',
+      requires: [],
+      signature: '',
+      parameters: [],
+      returns: {},
+      types: {},
+    };
+
     doc.description = getNodeJsDoc(node);
     doc.requires = getJsDocRequires(node);
 
@@ -317,7 +319,62 @@ function extractHookDoc(relPath) {
       }
     }
 
-    doc.signature = buildSignature(name ? name.getText(sourceFile) : hookName, doc.parameters, Object.keys(doc.returns));
+    const funcName = name ? name.getText(sourceFile) : relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
+    doc.signature = buildSignature(funcName, doc.parameters, Object.keys(doc.returns));
+    entries.push(doc);
+  }
+
+  /**
+   * Processes an exported provider component (non-`use*` function with JSDoc)
+   * and pushes a component entry. Props are extracted from the first parameter type.
+   */
+  function processComponentNode(node, name) {
+    const doc = {
+      source: relPath,
+      kind: 'component',
+      description: '',
+      requires: [],
+      signature: '',
+      props: {},
+      types: {},
+    };
+
+    doc.description = getNodeJsDoc(node);
+    doc.requires = getJsDocRequires(node);
+
+    // Extract props by inspecting the first parameter's resolved type.
+    // For generic components (e.g. DContextProvider<T>) the checker resolves
+    // Partial<Props<T>> at the declaration site, enumerating all prop names.
+    if (node.parameters?.length > 0) {
+      const firstParam = node.parameters[0];
+      const paramType = checker.getTypeAtLocation(firstParam);
+      checker.getPropertiesOfType(paramType).forEach((prop) => {
+        const symbolDoc = ts.displayPartsToString(
+          prop.getDocumentationComment(checker),
+        ).trim();
+        const propType = checker.getTypeOfSymbolAtLocation(prop, node);
+        // eslint-disable-next-line no-bitwise
+        const isOptional = !!(Number(prop.flags) & Number(ts.SymbolFlags.Optional));
+        doc.props[prop.name] = {
+          description: symbolDoc,
+          ...resolveTypeInfo(propType, checker, node),
+          required: !isOptional,
+        };
+      });
+    }
+
+    const funcName = name ? name.getText(sourceFile) : 'Component';
+    const propList = Object.entries(doc.props)
+      .filter(([, p]) => p.required)
+      .map(([n]) => n)
+      .concat(
+        Object.entries(doc.props)
+          .filter(([, p]) => !p.required)
+          .map(([n]) => `${n}?`),
+      )
+      .join(', ');
+    doc.signature = `${funcName}({ ${propList} }) => JSX.Element`;
+    entries.push(doc);
   }
 
   ts.forEachChild(sourceFile, (node) => {
@@ -338,7 +395,7 @@ function extractHookDoc(relPath) {
       // Only include types that have JSDoc documentation (public API surface).
       if (nodeDescription) {
         const declType = checker.getTypeAtLocation(node.name);
-        doc.types[node.name.text] = {
+        sharedTypes[node.name.text] = {
           description: nodeDescription,
           ...resolveTypeInfo(declType, checker, node),
         };
@@ -349,18 +406,22 @@ function extractHookDoc(relPath) {
       if (isDefault) {
         // `export default function useXxx()` — original pattern (e.g. useDToast)
         processHookNode(node, node.name ?? null);
-      } else if (
-        node.name
-        && node.name.text.startsWith('use')
-      ) {
-        // `export function useXxx()` — named export pattern (e.g. useDPortalContext)
-        hookName = node.name.text;
+      } else if (node.name && node.name.text.startsWith('use')) {
+        // `export function useXxx()` — named export hook (e.g. useDPortalContext)
         processHookNode(node, node.name);
+      } else if (node.name && getNodeJsDoc(node)) {
+        // `export function XxxProvider()` with JSDoc — documented provider component
+        processComponentNode(node, node.name);
       }
     }
   });
 
-  return doc;
+  // Attach shared types to every entry from this file.
+  entries.forEach((entry) => {
+    entry.types = { ...sharedTypes };
+  });
+
+  return entries;
 }
 
 // --- Run ---
@@ -371,14 +432,13 @@ let failed = 0;
 HOOK_FILES.forEach((relPath) => {
   const fileBaseName = relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
   try {
-    const hookDoc = extractHookDoc(relPath);
-    // Use the hook function name extracted from the source (e.g. useDPortalContext)
-    // rather than the file name (e.g. DPortalContext) as the JSON key.
-    const key = hookDoc.signature
-      ? hookDoc.signature.split('(')[0]
-      : fileBaseName;
-    hooksSection[key] = hookDoc;
-    process.stdout.write(`  ok ${key}\n`);
+    const docs = extractFileDocs(relPath);
+    docs.forEach((doc) => {
+      // Use the function name from the signature as the JSON key.
+      const key = doc.signature.split('(')[0];
+      hooksSection[key] = doc;
+      process.stdout.write(`  ok ${key} [${doc.kind}]\n`);
+    });
   } catch (err) {
     process.stderr.write(`  FAIL ${fileBaseName}: ${err.message}\n`);
     failed += 1;

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -188,6 +188,17 @@ function getJsDocRequires(node) {
 }
 
 /**
+ * Reads `@throws` JSDoc tags from a node and returns the first description found,
+ * or `undefined` if no `@throws` tag is present.
+ */
+function getJsDocThrows(node) {
+  const tag = ts.getJSDocTags(node).find(
+    (t) => t.tagName && t.tagName.text === 'throws',
+  );
+  return tag ? jsDocCommentToString(tag.comment) || undefined : undefined;
+}
+
+/**
  * Extracts the call parameters of a function-typed symbol using the type checker.
  * Returns [{ name, type, required, description }].
  */
@@ -237,7 +248,7 @@ function buildSignature(hookName, parameters, returnKeys) {
  * exported hook (`use*`) or documented provider component found in the file.
  *
  * Each hook entry:
- * { source, kind:'hook', description, requires, signature, parameters, returns, types }
+ * { source, kind:'hook', description, requires, throws?, signature, parameters, returns, types }
  *
  * Each component entry:
  * { source, kind:'component', description, requires, signature, props, types }
@@ -274,6 +285,8 @@ function extractFileDocs(relPath) {
 
     doc.description = getNodeJsDoc(node);
     doc.requires = getJsDocRequires(node);
+    const hookThrows = getJsDocThrows(node);
+    if (hookThrows) doc.throws = hookThrows;
 
     // Hook-level parameters (typically none for React hooks)
     doc.parameters = (node.parameters ?? []).map((param) => ({

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -90,11 +90,12 @@ function typeNodeText(typeNode, sourceFile) {
  *
  * @param {boolean} [expand=false] When true, always expand object types inline
  *   even when they have a named alias (used for the top-level `types` section).
- *   When false (default), a type with a user-defined alias symbol is emitted as
- *   `{ type: "AliasName" }` instead of being expanded — this produces cleaner
- *   references such as `CurrencyProps` instead of an anonymous `object` with fields.
+ * @param {Set<string>} [knownTypeNames] Set of type names that are documented in
+ *   `sharedTypes`. Only types in this set are emitted as named references; all
+ *   other aliased types (library types, unexported aliases, etc.) fall through to
+ *   the expand / typeToString path so consumers always get a usable definition.
  */
-function resolveTypeInfo(type, checker, locationNode, depth = 0, expand = false) {
+function resolveTypeInfo(type, checker, locationNode, depth = 0, expand = false, knownTypeNames = new Set()) {
   if (depth > 3) return { type: checker.typeToString(type) };
 
   // Guard primitive types before getPropertiesOfType, which would otherwise
@@ -114,7 +115,7 @@ function resolveTypeInfo(type, checker, locationNode, depth = 0, expand = false)
       return { type: 'string', values: nonUndefined.map((t) => t.value) };
     }
     if (nonUndefined.length === 1) {
-      return resolveTypeInfo(nonUndefined[0], checker, locationNode, depth, expand);
+      return resolveTypeInfo(nonUndefined[0], checker, locationNode, depth, expand, knownTypeNames);
     }
     return { type: checker.typeToString(type) };
   }
@@ -127,11 +128,11 @@ function resolveTypeInfo(type, checker, locationNode, depth = 0, expand = false)
     return { type: `${elemStr}[]` };
   }
 
-  // Named type aliases (e.g. CurrencyProps, BreakpointProps) — when expand is
-  // false, emit the alias name as a reference instead of expanding inline.
-  // This keeps prop definitions clean and avoids duplicating the type details
-  // that are already present in the `types` section of the API output.
-  if (!expand && type.aliasSymbol) {
+  // Named type aliases — only emit the alias name when it is a *documented*
+  // type present in sharedTypes (e.g. CurrencyProps, BreakpointProps).
+  // Library types (ReactNode, Partial<...>) and unexported aliases are NOT in
+  // knownTypeNames so they fall through to expand / typeToString instead.
+  if (!expand && type.aliasSymbol && knownTypeNames.has(type.aliasSymbol.name)) {
     return { type: checker.typeToString(type) };
   }
 
@@ -147,7 +148,7 @@ function resolveTypeInfo(type, checker, locationNode, depth = 0, expand = false)
       fields[prop.name] = {
         // Nested fields within an explicitly expanded type never get further
         // expand=true to avoid infinite recursion on self-referential types.
-        ...resolveTypeInfo(propType, checker, locationNode, depth + 1),
+        ...resolveTypeInfo(propType, checker, locationNode, depth + 1, false, knownTypeNames),
         required: !isOptional,
         ...(desc ? { description: desc } : {}),
       };
@@ -261,6 +262,18 @@ function extractFileDocs(relPath) {
   const sourceFile = program.getSourceFile(filePath);
   if (!sourceFile) throw new Error(`Could not load source file: ${filePath}`);
 
+  // Pre-scan: collect names of exported type aliases / interfaces that have JSDoc.
+  // Only these names will be emitted as references in props/returns; library types
+  // and unexported aliases will be expanded or stringified instead.
+  const knownTypeNames = new Set();
+  ts.forEachChild(sourceFile, (node) => {
+    // eslint-disable-next-line no-bitwise
+    const isExported = !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export);
+    if (isExported && (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node))) {
+      if (getNodeJsDoc(node)) knownTypeNames.add(node.name.text);
+    }
+  });
+
   // Exported types with JSDoc — shared across all entries from this file.
   const sharedTypes = {};
 
@@ -361,7 +374,7 @@ function extractFileDocs(relPath) {
               // Non-callable return value (plain data property) — emit type info.
               doc.returns[prop.name] = {
                 description,
-                ...resolveTypeInfo(propType, checker, node),
+                ...resolveTypeInfo(propType, checker, node, 0, false, knownTypeNames),
               };
             }
           });
@@ -407,8 +420,7 @@ function extractFileDocs(relPath) {
         const isOptional = !!(Number(prop.flags) & Number(ts.SymbolFlags.Optional));
         doc.props[prop.name] = {
           description: symbolDoc,
-          ...resolveTypeInfo(propType, checker, node),
-          required: !isOptional,
+          ...resolveTypeInfo(propType, checker, node, 0, false, knownTypeNames),
         };
       });
     }
@@ -449,7 +461,7 @@ function extractFileDocs(relPath) {
           description: nodeDescription,
           // expand=true: always expand fields in the types section even when
           // the type has a named alias (e.g. CurrencyProps itself).
-          ...resolveTypeInfo(declType, checker, node, 0, true),
+          ...resolveTypeInfo(declType, checker, node, 0, true, knownTypeNames),
         };
       }
     }

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -480,6 +480,7 @@ function extractFileDocs(relPath) {
 // --- Run ---
 process.stdout.write('Generating docs/api.json...\n');
 const hooksSection = {};
+const contextsSection = {};
 let failed = 0;
 
 HOOK_FILES.forEach((relPath) => {
@@ -489,7 +490,12 @@ HOOK_FILES.forEach((relPath) => {
     docs.forEach((doc) => {
       // Use the function name from the signature as the JSON key.
       const key = doc.signature.split('(')[0];
-      hooksSection[key] = doc;
+      if (doc.kind === 'component') {
+        // Provider components go into the dedicated `contexts` section.
+        contextsSection[key] = doc;
+      } else {
+        hooksSection[key] = doc;
+      }
       process.stdout.write(`  ok ${key} [${doc.kind}]\n`);
     });
   } catch (err) {
@@ -516,6 +522,7 @@ const apiOutput = {
   version,
   components: componentsSection,
   hooks: hooksSection,
+  contexts: contextsSection,
 };
 
 const OUTPUT_PATH = resolve(OUTPUT_DIR, 'api.json');
@@ -525,6 +532,7 @@ writeFileSync(OUTPUT_PATH, output);
 const sizeKB = (Buffer.byteLength(output) / 1024).toFixed(1);
 process.stdout.write('\nGenerated docs/api.json\n');
 process.stdout.write(`  Hooks: ${Object.keys(hooksSection).length} documented, ${failed} failed\n`);
+process.stdout.write(`  Contexts: ${Object.keys(contextsSection).length} documented\n`);
 process.stdout.write(`  Components: ${Object.keys(componentsSection).length} included\n`);
 process.stdout.write(`  Size: ${sizeKB} KB\n`);
 

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -420,6 +420,7 @@ function extractFileDocs(relPath) {
         const isOptional = !!(Number(prop.flags) & Number(ts.SymbolFlags.Optional));
         doc.props[prop.name] = {
           description: symbolDoc,
+          required: !isOptional,
           ...resolveTypeInfo(propType, checker, node, 0, false, knownTypeNames),
         };
       });

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -41,6 +41,7 @@ if (!existsSync(TSCONFIG_PATH)) {
 // --- Public hook files to document (relative to project root) ---
 const HOOK_FILES = [
   'src/components/DToastContainer/useDToast.tsx',
+  'src/contexts/DPortalContext.tsx',
 ];
 
 // --- Load tsconfig ---
@@ -226,7 +227,9 @@ function extractHookDoc(relPath) {
   const sourceFile = program.getSourceFile(filePath);
   if (!sourceFile) throw new Error(`Could not load source file: ${filePath}`);
 
-  const hookName = relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
+  // hookName is derived from the file name as a fallback; overridden below when
+  // a named exported function whose name starts with "use" is found.
+  let hookName = relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
   const doc = {
     source: relPath,
     description: '',
@@ -236,6 +239,86 @@ function extractHookDoc(relPath) {
     returns: {},
     types: {},
   };
+
+  /**
+   * Processes a function declaration node that is the hook entry point.
+   * Shared by both `export default function` and `export function useXxx`.
+   */
+  function processHookNode(node, name) {
+    doc.description = getNodeJsDoc(node);
+    doc.requires = getJsDocRequires(node);
+
+    // Hook-level parameters (typically none for React hooks)
+    doc.parameters = (node.parameters ?? []).map((param) => ({
+      name: param.name.getText(sourceFile),
+      // For generic hooks the type annotation may reference a type parameter (e.g. T).
+      // We preserve it as a readable string rather than trying to expand it.
+      type: typeNodeText(param.type, sourceFile),
+      required: !param.questionToken && !param.initializer,
+      description: getNodeJsDoc(param),
+    }));
+
+    // Collect JSDoc from `const x = useCallback(...)` declarations inside the body.
+    // TypeScript attaches doc comments to variable declarations, not return symbols,
+    // so we pre-build maps of variable name → { description, paramDescriptions }
+    // for the return enrichment step.
+    const innerJsDoc = {};
+    const innerParamDescriptions = {};
+    if (node.body) {
+      ts.forEachChild(node.body, (stmt) => {
+        if (
+          ts.isVariableStatement(stmt)
+          && stmt.declarationList
+          && stmt.declarationList.declarations.length
+        ) {
+          const decl = stmt.declarationList.declarations[0];
+          if (decl.name && ts.isIdentifier(decl.name)) {
+            const jsDoc = getNodeJsDoc(stmt);
+            if (jsDoc) innerJsDoc[decl.name.text] = jsDoc;
+            const paramMap = getJsDocParamDescriptions(stmt);
+            if (Object.keys(paramMap).length) {
+              innerParamDescriptions[decl.name.text] = paramMap;
+            }
+          }
+        }
+      });
+    }
+
+    // Use the type checker to inspect the hook's return type.
+    // For generic hooks (e.g. useDPortalContext<T>()) the checker resolves the
+    // instantiated return type at the declaration site, which gives us the
+    // property names we need even if their types reference type parameters.
+    if (name) {
+      const hookSymbol = checker.getSymbolAtLocation(name);
+      if (hookSymbol) {
+        const hookType = checker.getTypeOfSymbolAtLocation(hookSymbol, node);
+        const sigs = checker.getSignaturesOfType(hookType, ts.SignatureKind.Call);
+        if (sigs.length) {
+          const returnType = checker.getReturnTypeOfSignature(sigs[0]);
+          checker.getPropertiesOfType(returnType).forEach((prop) => {
+            const symbolDoc = ts.displayPartsToString(
+              prop.getDocumentationComment(checker),
+            ).trim();
+            doc.returns[prop.name] = {
+              description: symbolDoc || innerJsDoc[prop.name] || '',
+              parameters: extractCallParams(prop, checker, node).map((p) => ({
+                ...p,
+                description:
+                  p.description
+                  || (innerParamDescriptions[prop.name] ?? {})[p.name]
+                  || '',
+              })),
+              returns: {
+                type: extractReturnTypeString(prop, checker, node),
+              },
+            };
+          });
+        }
+      }
+    }
+
+    doc.signature = buildSignature(name ? name.getText(sourceFile) : hookName, doc.parameters, Object.keys(doc.returns));
+  }
 
   ts.forEachChild(sourceFile, (node) => {
     // eslint-disable-next-line no-bitwise
@@ -247,86 +330,33 @@ function extractHookDoc(relPath) {
 
     // Collect exported type aliases and interfaces — fully resolved via the type checker
     // so referenced types (e.g. ComponentStateColor) are expanded inline.
+    // Skip types that are purely internal implementation details (no JSDoc description).
     const isExportedTypeOrInterface = isExported
       && (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node));
     if (isExportedTypeOrInterface) {
-      const declType = checker.getTypeAtLocation(node.name);
-      doc.types[node.name.text] = {
-        description: getNodeJsDoc(node),
-        ...resolveTypeInfo(declType, checker, node),
-      };
+      const nodeDescription = getNodeJsDoc(node);
+      // Only include types that have JSDoc documentation (public API surface).
+      if (nodeDescription) {
+        const declType = checker.getTypeAtLocation(node.name);
+        doc.types[node.name.text] = {
+          description: nodeDescription,
+          ...resolveTypeInfo(declType, checker, node),
+        };
+      }
     }
 
-    // Process the default-exported hook function
-    if (ts.isFunctionDeclaration(node) && isExported && isDefault) {
-      doc.description = getNodeJsDoc(node);
-      doc.requires = getJsDocRequires(node);
-
-      // Hook-level parameters (typically none for React hooks)
-      doc.parameters = (node.parameters ?? []).map((param) => ({
-        name: param.name.getText(sourceFile),
-        type: typeNodeText(param.type, sourceFile),
-        required: !param.questionToken && !param.initializer,
-        description: getNodeJsDoc(param),
-      }));
-
-      // Collect JSDoc from `const x = useCallback(...)` declarations inside the body.
-      // TypeScript attaches doc comments to variable declarations, not return symbols,
-      // so we pre-build maps of variable name → { description, paramDescriptions }
-      // for the return enrichment step.
-      const innerJsDoc = {};
-      const innerParamDescriptions = {};
-      if (node.body) {
-        ts.forEachChild(node.body, (stmt) => {
-          if (
-            ts.isVariableStatement(stmt)
-            && stmt.declarationList
-            && stmt.declarationList.declarations.length
-          ) {
-            const decl = stmt.declarationList.declarations[0];
-            if (decl.name && ts.isIdentifier(decl.name)) {
-              const jsDoc = getNodeJsDoc(stmt);
-              if (jsDoc) innerJsDoc[decl.name.text] = jsDoc;
-              const paramMap = getJsDocParamDescriptions(stmt);
-              if (Object.keys(paramMap).length) {
-                innerParamDescriptions[decl.name.text] = paramMap;
-              }
-            }
-          }
-        });
+    if (ts.isFunctionDeclaration(node) && isExported) {
+      if (isDefault) {
+        // `export default function useXxx()` — original pattern (e.g. useDToast)
+        processHookNode(node, node.name ?? null);
+      } else if (
+        node.name
+        && node.name.text.startsWith('use')
+      ) {
+        // `export function useXxx()` — named export pattern (e.g. useDPortalContext)
+        hookName = node.name.text;
+        processHookNode(node, node.name);
       }
-
-      // Use the type checker to inspect the hook's return type
-      if (node.name) {
-        const hookSymbol = checker.getSymbolAtLocation(node.name);
-        if (hookSymbol) {
-          const hookType = checker.getTypeOfSymbolAtLocation(hookSymbol, node);
-          const sigs = checker.getSignaturesOfType(hookType, ts.SignatureKind.Call);
-          if (sigs.length) {
-            const returnType = checker.getReturnTypeOfSignature(sigs[0]);
-            checker.getPropertiesOfType(returnType).forEach((prop) => {
-              const symbolDoc = ts.displayPartsToString(
-                prop.getDocumentationComment(checker),
-              ).trim();
-              doc.returns[prop.name] = {
-                description: symbolDoc || innerJsDoc[prop.name] || '',
-                parameters: extractCallParams(prop, checker, node).map((p) => ({
-                  ...p,
-                  description:
-                    p.description
-                    || (innerParamDescriptions[prop.name] ?? {})[p.name]
-                    || '',
-                })),
-                returns: {
-                  type: extractReturnTypeString(prop, checker, node),
-                },
-              };
-            });
-          }
-        }
-      }
-
-      doc.signature = buildSignature(hookName, doc.parameters, Object.keys(doc.returns));
     }
   });
 
@@ -339,12 +369,18 @@ const hooksSection = {};
 let failed = 0;
 
 HOOK_FILES.forEach((relPath) => {
-  const hookName = relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
+  const fileBaseName = relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
   try {
-    hooksSection[hookName] = extractHookDoc(relPath);
-    process.stdout.write(`  ok ${hookName}\n`);
+    const hookDoc = extractHookDoc(relPath);
+    // Use the hook function name extracted from the source (e.g. useDPortalContext)
+    // rather than the file name (e.g. DPortalContext) as the JSON key.
+    const key = hookDoc.signature
+      ? hookDoc.signature.split('(')[0]
+      : fileBaseName;
+    hooksSection[key] = hookDoc;
+    process.stdout.write(`  ok ${key}\n`);
   } catch (err) {
-    process.stderr.write(`  FAIL ${hookName}: ${err.message}\n`);
+    process.stderr.write(`  FAIL ${fileBaseName}: ${err.message}\n`);
     failed += 1;
   }
 });

--- a/scripts/generate-hooks.mjs
+++ b/scripts/generate-hooks.mjs
@@ -230,6 +230,15 @@ function extractReturnTypeString(symbol, checker, locationNode) {
 }
 
 /**
+ * Returns a TypeScript-style generic type parameter string for a node, e.g. `<T, U>`.
+ * Returns an empty string when the node has no type parameters.
+ */
+function getTypeParamsStr(node) {
+  if (!node.typeParameters?.length) return '';
+  return `<${node.typeParameters.map((tp) => tp.name.text).join(', ')}>`;
+}
+
+/**
  * Builds a TypeScript-style signature string for a hook.
  * Example: `useDToast() => { toast }`
  */
@@ -383,7 +392,9 @@ function extractFileDocs(relPath) {
     }
 
     const funcName = name ? name.getText(sourceFile) : relPath.split('/').pop().replace(/\.(tsx?|jsx?)$/, '');
-    doc.signature = buildSignature(funcName, doc.parameters, Object.keys(doc.returns));
+    const typeParams = getTypeParamsStr(node);
+    doc.name = funcName;
+    doc.signature = buildSignature(`${funcName}${typeParams}`, doc.parameters, Object.keys(doc.returns));
     entries.push(doc);
   }
 
@@ -427,6 +438,8 @@ function extractFileDocs(relPath) {
     }
 
     const funcName = name ? name.getText(sourceFile) : 'Component';
+    const typeParams = getTypeParamsStr(node);
+    doc.name = funcName;
     const propList = Object.entries(doc.props)
       .filter(([, p]) => p.required)
       .map(([n]) => n)
@@ -436,7 +449,7 @@ function extractFileDocs(relPath) {
           .map(([n]) => `${n}?`),
       )
       .join(', ');
-    doc.signature = `${funcName}({ ${propList} }) => JSX.Element`;
+    doc.signature = `${funcName}${typeParams}({ ${propList} }) => JSX.Element`;
     entries.push(doc);
   }
 
@@ -500,8 +513,8 @@ HOOK_FILES.forEach((relPath) => {
   try {
     const docs = extractFileDocs(relPath);
     docs.forEach((doc) => {
-      // Use the function name from the signature as the JSON key.
-      const key = doc.signature.split('(')[0];
+      // Use the dedicated `name` field as the JSON key (the signature may include generics).
+      const key = doc.name;
       if (doc.kind === 'component') {
         // Provider components go into the dedicated `contexts` section.
         contextsSection[key] = doc;

--- a/src/contexts/DContext.tsx
+++ b/src/contexts/DContext.tsx
@@ -16,10 +16,17 @@ import { PREFIX_BS } from '../components/config';
 import type { AlertThemeIconMap } from '../components/interface';
 import getCssVariable from '../utils/getCssVariable';
 
+/**
+ * Currency formatting configuration used by `DContextProvider`.
+ */
 export type CurrencyProps = {
+  /** Currency symbol (e.g. `"$"`, `"€"`). */
   symbol: string;
+  /** Number of decimal places (e.g. `2`). */
   precision: number;
+  /** Thousands separator character (e.g. `","`). */
   separator: string;
+  /** Decimal separator character (e.g. `"."`). */
   decimal: string;
 };
 
@@ -49,12 +56,22 @@ type IconMapProps = {
   };
 };
 
+/**
+ * CSS breakpoint pixel values resolved from Bootstrap CSS variables at runtime.
+ * These are populated automatically by `DContextProvider` on mount.
+ */
 export type BreakpointProps = {
+  /** `--bs-breakpoint-xs` value (usually `"0px"`). */
   xs: string;
+  /** `--bs-breakpoint-sm` value (usually `"576px"`). */
   sm: string;
+  /** `--bs-breakpoint-md` value (usually `"768px"`). */
   md: string;
+  /** `--bs-breakpoint-lg` value (usually `"992px"`). */
   lg: string;
+  /** `--bs-breakpoint-xl` value (usually `"1200px"`). */
   xl: string;
+  /** `--bs-breakpoint-xxl` value (usually `"1400px"`). */
   xxl: string;
 };
 
@@ -121,6 +138,14 @@ const DEFAULT_STATE = {
 
 export const DContext = createContext<Partial<Context<any>>>(DEFAULT_STATE);
 
+/**
+ * Root context provider for Dynamic UI. Wrap your application with this
+ * component to configure icons, currency, language, and portal settings
+ * for all descendant Dynamic UI components.
+ *
+ * @template T - Map of portal name → payload shape (e.g. `{ modal: { title: string } }`).
+ *   Pass it once at the top level: `<DContextProvider<MyPortals> ...>`.
+ */
 export function DContextProvider<T extends Record<string, unknown>>(
   {
     language = DEFAULT_STATE.language,
@@ -180,6 +205,14 @@ export function DContextProvider<T extends Record<string, unknown>>(
   );
 }
 
+/**
+ * Returns the Dynamic UI context value set by `DContextProvider`.
+ * Use it to read or update icon, currency, language, and portal configuration.
+ *
+ * @requires DContextProvider
+ * @template T - Map of portal name → payload shape. Must match the type passed
+ *   to the nearest `DContextProvider`.
+ */
 export function useDContext<T extends Record<string, unknown>>() {
   const context = useContext(DContext) as Context<T>;
 

--- a/src/contexts/DContext.tsx
+++ b/src/contexts/DContext.tsx
@@ -233,18 +233,13 @@ export function DContextProvider<T extends Record<string, unknown>>(
 
 /**
  * Returns the Dynamic UI context value set by `DContextProvider`.
- * Use it to read or update icon, currency, language, and portal configuration.
+ * Falls back to the library's built-in defaults when no `DContextProvider`
+ * is present in the tree — wrap your application with `DContextProvider`
+ * to customise icons, currency, language, and portal settings.
  *
- * @requires DContextProvider
  * @template T - Map of portal name → payload shape. Must match the type passed
  *   to the nearest `DContextProvider`.
  */
 export function useDContext<T extends Record<string, unknown>>() {
-  const context = useContext(DContext) as Context<T>;
-
-  if (context === undefined) {
-    throw new Error('useDContext was used outside of DContextProvider');
-  }
-
-  return context;
+  return useContext(DContext) as Context<T>;
 }

--- a/src/contexts/DContext.tsx
+++ b/src/contexts/DContext.tsx
@@ -101,16 +101,18 @@ export type BreakpointProps = {
   xxl: string;
 };
 
-type Props<T extends Record<string, unknown>> = {
+type Props = {
   language: string;
   currency: CurrencyProps,
   icon: IconProps;
   iconMap: IconMapProps;
   breakpoints: BreakpointProps;
-} & PortalContextProps<T>;
+};
 
-type Context<T extends Record<string, unknown>> = Props<T> & {
-  setContext: (value: Partial<Props<T>>) => void;
+type DContextProviderProps<T extends Record<string, unknown>> = Props & PortalContextProps<T>;
+
+type Context = Props & {
+  setContext: (value: Partial<Props>) => void;
 };
 
 const DEFAULT_STATE = {
@@ -159,10 +161,9 @@ const DEFAULT_STATE = {
     xxl: '',
   },
   setContext: () => {},
-  portalName: 'd-portal',
 };
 
-export const DContext = createContext<Partial<Context<any>>>(DEFAULT_STATE);
+export const DContext = createContext<Partial<Context>>(DEFAULT_STATE);
 
 /**
  * Root context provider for Dynamic UI. Wrap your application with this
@@ -178,15 +179,15 @@ export function DContextProvider<T extends Record<string, unknown>>(
     currency = DEFAULT_STATE.currency,
     icon = DEFAULT_STATE.icon,
     iconMap = DEFAULT_STATE.iconMap,
-    portalName = DEFAULT_STATE.portalName,
+    portalName = 'd-portal',
     availablePortals,
     children,
-  }: PropsWithChildren<Partial<Props<T>>>,
+  }: PropsWithChildren<Partial<DContextProviderProps<T>>>,
 ) {
   const [
     internalContext,
     setInternalContext,
-  ] = useState<Partial<Props<T>>>({
+  ] = useState<Partial<Props>>({
     language,
     currency,
     icon,
@@ -194,7 +195,7 @@ export function DContextProvider<T extends Record<string, unknown>>(
     breakpoints: DEFAULT_STATE.breakpoints,
   });
 
-  const setContext = useCallback((newValue: Partial<Props<T>>) => (
+  const setContext = useCallback((newValue: Partial<Props>) => (
     setInternalContext((prevInternalContext) => ({
       ...prevInternalContext,
       ...newValue,
@@ -236,10 +237,7 @@ export function DContextProvider<T extends Record<string, unknown>>(
  * Falls back to the library's built-in defaults when no `DContextProvider`
  * is present in the tree — wrap your application with `DContextProvider`
  * to customise icons, currency, language, and portal settings.
- *
- * @template T - Map of portal name → payload shape. Must match the type passed
- *   to the nearest `DContextProvider`.
  */
-export function useDContext<T extends Record<string, unknown>>() {
-  return useContext(DContext) as Context<T>;
+export function useDContext() {
+  return useContext(DContext) as Context;
 }

--- a/src/contexts/DContext.tsx
+++ b/src/contexts/DContext.tsx
@@ -30,28 +30,54 @@ export type CurrencyProps = {
   decimal: string;
 };
 
-type IconProps = {
+/**
+ * Icon font configuration used by `DContextProvider` to resolve icon classes.
+ */
+export type IconProps = {
+  /** CSS class that identifies the icon font family (e.g. `"bi"`). */
   familyClass: string;
+  /** CSS prefix for icon names within the family (e.g. `"bi-"`). */
   familyPrefix: string;
+  /** When `true`, icons are rendered in Material Design outlined style. */
   materialStyle: boolean;
 };
 
-type IconMapProps = {
+/**
+ * Map of semantic icon names to their icon-font class suffixes.
+ * Used by Dynamic UI components to look up icons consistently.
+ */
+export type IconMapProps = {
+  /** Class suffix for the generic close/dismiss icon. */
   x: string;
+  /** Class suffix for the large close/dismiss icon. */
   xLg: string;
+  /** Class suffix for the chevron-down icon. */
   chevronDown: string;
+  /** Class suffix for the chevron-up icon. */
   chevronUp: string;
+  /** Class suffix for the chevron-left icon. */
   chevronLeft: string;
+  /** Class suffix for the chevron-right icon. */
   chevronRight: string;
+  /** Per-state alert icon map (one icon per `ComponentStateColor` value). */
   alert: AlertThemeIconMap;
+  /** Class suffix for the upload/attach icon. */
   upload: string;
+  /** Class suffix for the calendar/date-picker icon. */
   calendar: string;
+  /** Class suffix for the checkmark icon. */
   check: string;
+  /** Icon class suffixes for text input adornments. */
   input: {
+    /** Search/magnifier icon. */
     search: string;
+    /** Show password icon. */
     show: string;
+    /** Hide password icon. */
     hide: string;
+    /** Numeric decrease icon. */
     decrease: string;
+    /** Numeric increase icon. */
     increase: string;
   };
 };

--- a/src/contexts/DContext.tsx
+++ b/src/contexts/DContext.tsx
@@ -163,7 +163,7 @@ const DEFAULT_STATE = {
   setContext: () => {},
 };
 
-export const DContext = createContext<Partial<Context>>(DEFAULT_STATE);
+export const DContext = createContext<Context>(DEFAULT_STATE);
 
 /**
  * Root context provider for Dynamic UI. Wrap your application with this
@@ -187,7 +187,7 @@ export function DContextProvider<T extends Record<string, unknown>>(
   const [
     internalContext,
     setInternalContext,
-  ] = useState<Partial<Props>>({
+  ] = useState<Props>({
     language,
     currency,
     icon,
@@ -239,5 +239,5 @@ export function DContextProvider<T extends Record<string, unknown>>(
  * to customise icons, currency, language, and portal settings.
  */
 export function useDContext() {
-  return useContext(DContext) as Context;
+  return useContext(DContext);
 }

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -49,13 +49,25 @@ type OpenPortalFunction<T extends Record<string, unknown>> = <K extends keyof T>
 type ClosePortalFunction = () => void;
 
 /**
+ * Consumer-facing shape of a single entry in the portal stack.
+ * Only exposes `name` and `payload` — the internal `Component` field is not part of the public API.
+ * @template T - Map of portal name → payload shape.
+ */
+export type PortalStackEntry<T extends Record<string, unknown>> = {
+  /** Portal identifier — matches the key passed to `openPortal`. */
+  name: keyof T & string;
+  /** Payload forwarded from `openPortal`. */
+  payload: T[keyof T];
+};
+
+/**
  * Value returned by `useDPortalContext`. Provides methods to open/close portals
  * and inspect the current portal stack.
  * @template T - Map of portal name → payload shape.
  */
 export type PortalContextType<T extends Record<string, unknown>> = {
   /** Currently open portals, ordered from oldest (bottom) to newest (top). */
-  stack: PortalStackItem<string, T[keyof T]>[];
+  stack: PortalStackEntry<T>[];
   /**
    * Pushes a named portal onto the stack, rendering its registered component
    * with the given payload.
@@ -94,18 +106,19 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
   useDisableBodyScrollEffect(Boolean(stack.length));
 
   const openPortal = useCallback(
-    (name: keyof T, payload: T[keyof T]) => {
+    // eslint-disable-next-line prefer-arrow-callback
+    function openPortalImpl<K extends keyof T>(name: K, payload: T[K]) {
       if (!availablePortals) {
-        throw new Error(`there is no component for portal ${name.toString()}`);
+        throw new Error(`there is no component for portal ${String(name)}`);
       }
 
-      const Component = availablePortals[name] as PortalComponent<T[keyof T]>;
+      const Component = availablePortals[name] as PortalComponent<T[K]>;
       if (!Component) {
-        throw new Error(`there is no component for portal ${name.toString()}`);
+        throw new Error(`there is no component for portal ${String(name)}`);
       }
       push({
         name: name as string,
-        Component,
+        Component: Component as PortalComponent<T[keyof T]>,
         payload,
       });
       (document.activeElement as HTMLElement)?.blur();

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -54,11 +54,13 @@ type ClosePortalFunction = () => void;
  * @template T - Map of portal name → payload shape.
  */
 export type PortalStackEntry<T extends Record<string, unknown>> = {
-  /** Portal identifier — matches the key passed to `openPortal`. */
-  name: keyof T & string;
-  /** Payload forwarded from `openPortal`. */
-  payload: T[keyof T];
-};
+  [K in keyof T]: {
+    /** Portal identifier — matches the key passed to `openPortal`. */
+    name: K & string;
+    /** Payload forwarded from `openPortal`. */
+    payload: T[K];
+  };
+}[keyof T];
 
 /**
  * Value returned by `useDPortalContext`. Provides methods to open/close portals
@@ -257,11 +259,11 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
  * ```
  */
 export function useDPortalContext<T extends Record<string, unknown>>(): PortalContextType<T> {
-  const context = useContext(DPortalContext) as PortalContextType<T>;
+  const context = useContext(DPortalContext);
 
   if (context === undefined) {
     throw new Error('useDPortalContext was used outside of DPortalContextProvider');
   }
 
-  return context;
+  return context as PortalContextType<T>;
 }

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -114,12 +114,18 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
     // eslint-disable-next-line prefer-arrow-callback
     function openPortalImpl<K extends keyof T & string>(name: K, payload: T[K]) {
       if (!availablePortals) {
-        throw new Error(`there is no component for portal ${String(name)}`);
+        throw new Error(
+          'openPortal was called but DContextProvider has no availablePortals configured. '
+          + 'Pass an availablePortals map to DContextProvider.',
+        );
       }
 
       const Component = availablePortals[name] as PortalComponent<T[K]>;
       if (!Component) {
-        throw new Error(`there is no component for portal ${String(name)}`);
+        throw new Error(
+          `No component registered for portal "${String(name)}". `
+          + `Ensure "${String(name)}" has an entry in the availablePortals map on DContextProvider.`,
+        );
       }
       // K is a specific member of keyof T & string so the object satisfies
       // InternalStackItem<T>, but TS can't verify generic-over-union assignability.

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -42,7 +42,7 @@ type PortalStackItem<N extends string = string, P = any> = {
   Component: PortalComponent<P>;
   payload: P;
 };
-type OpenPortalFunction<T extends Record<string, unknown>> = <K extends keyof T>(
+type OpenPortalFunction<T extends Record<string, unknown>> = <K extends keyof T & string>(
   name: K,
   payload: T[K],
 ) => void;
@@ -109,7 +109,7 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
 
   const openPortal = useCallback(
     // eslint-disable-next-line prefer-arrow-callback
-    function openPortalImpl<K extends keyof T>(name: K, payload: T[K]) {
+    function openPortalImpl<K extends keyof T & string>(name: K, payload: T[K]) {
       if (!availablePortals) {
         throw new Error(`there is no component for portal ${String(name)}`);
       }
@@ -119,7 +119,7 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
         throw new Error(`there is no component for portal ${String(name)}`);
       }
       push({
-        name: name as string,
+        name,
         Component: Component as PortalComponent<T[keyof T]>,
         payload,
       });

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -136,11 +136,16 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
     [isEmpty, pop],
   );
 
+  const publicStack = useMemo(
+    () => stack.map(({ name, payload }) => ({ name, payload })) as PortalStackEntry<T>[],
+    [stack],
+  );
+
   const value = useMemo(() => ({
-    stack,
+    stack: publicStack,
     openPortal,
     closePortal,
-  }), [stack, openPortal, closePortal]) as PortalContextType<any>;
+  }), [publicStack, openPortal, closePortal]) as PortalContextType<any>;
 
   const handleClose = useCallback((target: Element) => {
     if (!(target instanceof HTMLDivElement)) {

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -42,6 +42,9 @@ type PortalStackItem<N extends string = string, P = any> = {
   Component: PortalComponent<P>;
   payload: P;
 };
+type InternalStackItem<T extends Record<string, unknown>> = {
+  [K in keyof T & string]: PortalStackItem<K, T[K]>;
+}[keyof T & string];
 type OpenPortalFunction<T extends Record<string, unknown>> = <K extends keyof T & string>(
   name: K,
   payload: T[K],
@@ -104,8 +107,7 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
   }: PortalContextProps<T>,
 ) {
   const { created } = usePortal(portalName);
-  // eslint-disable-next-line max-len
-  const [stack, { push, pop, isEmpty }] = useStackState<PortalStackItem<keyof T & string, T[keyof T]>>([]);
+  const [stack, { push, pop, isEmpty }] = useStackState<InternalStackItem<T>>([]);
   useDisableBodyScrollEffect(Boolean(stack.length));
 
   const openPortal = useCallback(
@@ -119,11 +121,9 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
       if (!Component) {
         throw new Error(`there is no component for portal ${String(name)}`);
       }
-      push({
-        name,
-        Component: Component as PortalComponent<T[keyof T]>,
-        payload,
-      });
+      // K is a specific member of keyof T & string so the object satisfies
+      // InternalStackItem<T>, but TS can't verify generic-over-union assignability.
+      push({ name, Component, payload } as unknown as InternalStackItem<T>);
       (document.activeElement as HTMLElement)?.blur();
     },
     [availablePortals, push],

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -25,8 +25,16 @@ type PortalAvailableList<T extends Record<string, unknown>> = {
   [K in keyof T]: PortalComponent<T[K]>;
 };
 
+/**
+ * Props for the `DPortalContextProvider` (mounted internally by `DContextProvider`).
+ * Consumers should configure these props on `DContextProvider` directly — never
+ * use `DPortalContextProvider` directly.
+ * @template T - Map of portal name → payload shape (e.g. `{ modal: { title: string } }`).
+ */
 export type PortalContextProps<T extends Record<string, unknown>> = PropsWithChildren<{
+  /** DOM element id used as the portal mount point. */
   portalName: string;
+  /** Map of portal name to the component that renders it. */
   availablePortals?: PortalAvailableList<T>;
 }>;
 type PortalStackItem<N extends string = string, P = any> = {
@@ -36,14 +44,35 @@ type PortalStackItem<N extends string = string, P = any> = {
 };
 type OpenPortalFunction<P = unknown> = (name: string, payload: P) => void;
 type ClosePortalFunction = () => void;
+
+/**
+ * Value returned by `useDPortalContext`. Provides methods to open/close portals
+ * and inspect the current portal stack.
+ * @template T - Map of portal name → payload shape.
+ */
 export type PortalContextType<T extends Record<string, unknown>> = {
+  /** Currently open portals, ordered from oldest (bottom) to newest (top). */
   stack: PortalStackItem<string, T[keyof T]>[];
+  /**
+   * Pushes a named portal onto the stack, rendering its registered component
+   * with the given payload.
+   * @param name - Key of the portal to open (must be registered in `availablePortals`).
+   * @param payload - Data forwarded to the portal component via `PortalProps.payload`.
+   */
   openPortal: OpenPortalFunction<T[keyof T]>;
+  /** Pops the topmost portal off the stack, closing it. */
   closePortal: ClosePortalFunction;
 };
 
+/**
+ * Props interface received by every component registered in `availablePortals`.
+ * Use `PortalProps<Payloads['myPortal']>` to type a specific portal component.
+ * @template P - The payload shape for this portal.
+ */
 export type PortalProps<P = unknown> = {
+  /** Portal identifier, matches the key used in `openPortal`. */
   name: string;
+  /** Data passed via `openPortal`. */
   payload: P;
 };
 
@@ -184,11 +213,32 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
   );
 }
 
+/**
+ * Hook to open/close registered portals (modals, offcanvas, etc.).
+ *
+ * **Prerequisite**: must be called inside a `DContextProvider` configured with
+ * `portalName` and `availablePortals`. `DContextProvider` mounts
+ * `DPortalContextProvider` internally — consumers never use
+ * `DPortalContextProvider` directly.
+ *
+ * @template T - Map of portal name → payload shape (e.g. `ModalPayloads`).
+ *   Typing this generic gives you autocomplete on `openPortal` arguments.
+ * @returns `{ openPortal, closePortal, stack }` from the nearest portal context.
+ * @throws If called outside of `DContextProvider` / `DPortalContextProvider`.
+ *
+ * @requires DContextProvider
+ *
+ * @example
+ * ```tsx
+ * const { openPortal, closePortal } = useDPortalContext<ModalPayloads>();
+ * openPortal('confirm', { message: 'Are you sure?' });
+ * ```
+ */
 export function useDPortalContext<T extends Record<string, unknown>>(): PortalContextType<T> {
   const context = useContext(DPortalContext) as PortalContextType<T>;
 
   if (context === undefined) {
-    throw new Error('usePortalContext was used outside of PortalContextProvider');
+    throw new Error('useDPortalContext was used outside of DPortalContextProvider');
   }
 
   return context;

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -104,7 +104,8 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
   }: PortalContextProps<T>,
 ) {
   const { created } = usePortal(portalName);
-  const [stack, { push, pop, isEmpty }] = useStackState<PortalStackItem<string, T[keyof T]>>([]);
+  // eslint-disable-next-line max-len
+  const [stack, { push, pop, isEmpty }] = useStackState<PortalStackItem<keyof T & string, T[keyof T]>>([]);
   useDisableBodyScrollEffect(Boolean(stack.length));
 
   const openPortal = useCallback(

--- a/src/contexts/DPortalContext.tsx
+++ b/src/contexts/DPortalContext.tsx
@@ -42,7 +42,10 @@ type PortalStackItem<N extends string = string, P = any> = {
   Component: PortalComponent<P>;
   payload: P;
 };
-type OpenPortalFunction<P = unknown> = (name: string, payload: P) => void;
+type OpenPortalFunction<T extends Record<string, unknown>> = <K extends keyof T>(
+  name: K,
+  payload: T[K],
+) => void;
 type ClosePortalFunction = () => void;
 
 /**
@@ -58,8 +61,9 @@ export type PortalContextType<T extends Record<string, unknown>> = {
    * with the given payload.
    * @param name - Key of the portal to open (must be registered in `availablePortals`).
    * @param payload - Data forwarded to the portal component via `PortalProps.payload`.
+   *   TypeScript will enforce that `payload` matches the shape declared for `name` in `T`.
    */
-  openPortal: OpenPortalFunction<T[keyof T]>;
+  openPortal: OpenPortalFunction<T>;
   /** Pops the topmost portal off the stack, closing it. */
   closePortal: ClosePortalFunction;
 };
@@ -89,25 +93,25 @@ export function DPortalContextProvider<T extends Record<string, unknown>>(
   const [stack, { push, pop, isEmpty }] = useStackState<PortalStackItem<string, T[keyof T]>>([]);
   useDisableBodyScrollEffect(Boolean(stack.length));
 
-  const openPortal = useCallback<PortalContextType<T>['openPortal']>(
-    (name, payload) => {
+  const openPortal = useCallback(
+    (name: keyof T, payload: T[keyof T]) => {
       if (!availablePortals) {
         throw new Error(`there is no component for portal ${name.toString()}`);
       }
 
-      const Component = availablePortals[name as keyof T] as PortalComponent<T[keyof T]>;
+      const Component = availablePortals[name] as PortalComponent<T[keyof T]>;
       if (!Component) {
         throw new Error(`there is no component for portal ${name.toString()}`);
       }
       push({
-        name,
+        name: name as string,
         Component,
         payload,
       });
       (document.activeElement as HTMLElement)?.blur();
     },
     [availablePortals, push],
-  );
+  ) as PortalContextType<T>['openPortal'];
 
   const closePortal = useCallback<PortalContextType<T>['closePortal']>(
     () => {

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,3 +1,7 @@
 export * from './DContext';
 export { useDPortalContext } from './DPortalContext';
-export type { PortalProps } from './DPortalContext';
+export type {
+  PortalProps,
+  PortalContextType,
+  PortalContextProps,
+} from './DPortalContext';

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -4,4 +4,5 @@ export type {
   PortalProps,
   PortalContextType,
   PortalContextProps,
+  PortalStackEntry,
 } from './DPortalContext';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,7 +4,6 @@ export { default as useDisableInputWheel } from './useDisableInputWheel';
 export { default as useProvidedRefOrCreate } from './useProvidedRefOrCreate';
 export { default as useStackState } from './useStackState';
 export { default as useDisableBodyScrollEffect } from './useDisableBodyScrollEffect';
-export { default as usePortal } from './usePortal';
 export { default as useItemSelection } from './useItemSelection';
 export { default as useMediaQuery } from './useMediaQuery';
 export {

--- a/src/hooks/usePortal.ts
+++ b/src/hooks/usePortal.ts
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
 
+/**
+ * @internal
+ * Creates a DOM `<div>` portal mount point and appends it to `document.body`.
+ * This hook is used exclusively by `DPortalContextProvider` and is **not** part
+ * of the public API. Use `useDPortalContext` instead.
+ */
 export default function usePortal(portalName: string) {
   const [hasPortal, setHasPortal] = useState(false);
   useEffect(() => {

--- a/stories/context/DContext.stories.tsx
+++ b/stories/context/DContext.stories.tsx
@@ -8,7 +8,7 @@ import { CONTEXT_PROVIDER_CONFIG_MATERIAL } from '../config/constants';
  * Context Provider to share settings between components
  */
 const config: Meta<typeof DContextProvider> = {
-  title: 'Design System/Components/Context Provider',
+  title: 'Design System/Context/ContextProvider',
   component: DContextProvider,
   tags: ['autodocs'],
 };

--- a/stories/hooks/patterns/DModalPattern.mdx
+++ b/stories/hooks/patterns/DModalPattern.mdx
@@ -1,6 +1,6 @@
 import { Meta, Unstyled, Source } from "@storybook/addon-docs/blocks";
 
-import { ExampleModalRoot } from "./useModalExamples";
+import { ExampleModalRoot } from "./DModalPatternExamples";
 
 # Modal
 
@@ -83,7 +83,7 @@ export function ExampleModal({ payload }: PortalProps<ModalPayloads['example']>)
 ## Modal Setting on the main file `App.tsx`
 
 The available modals are configured on the `DContextProvider` so that they can
-then be opened with the `useDModalContext` hook. The payload type of the modals
+then be opened with the `useDPortalContext` hook. The payload type of the modals
 is only necessary if payload will be used.
 
 <Source

--- a/stories/hooks/patterns/DModalPatternExamples.tsx
+++ b/stories/hooks/patterns/DModalPatternExamples.tsx
@@ -1,11 +1,11 @@
 import {
   DContextProvider,
   useDPortalContext,
-} from '../../src';
-import DButton from '../../src/components/DButton';
-import DModal from '../../src/components/DModal/DModal';
+} from '../../../src';
+import DButton from '../../../src/components/DButton';
+import DModal from '../../../src/components/DModal/DModal';
 
-import type { PortalProps } from '../../src';
+import type { PortalProps } from '../../../src';
 
 type ModalPayloads = {
   example: {

--- a/stories/hooks/patterns/DOffcanvasPattern.mdx
+++ b/stories/hooks/patterns/DOffcanvasPattern.mdx
@@ -1,6 +1,6 @@
 import { Meta, Unstyled, Source } from "@storybook/addon-docs/blocks";
 
-import { ExampleOffcanvasRoot } from "./useOffcanvasExamples";
+import { ExampleOffcanvasRoot } from "./DOffcanvasPatternExamples";
 
 # Offcanvas
 
@@ -83,8 +83,8 @@ export function ExampleOffcanvas({ payload }: PortalProps<OffcanvasPayloads['exa
 
 ## Offcanvas Setting on the main file `App.tsx`
 
-The available offcanvas are configured on the `DOffcanvasContextProvider` so that they can
-then be opened with the `useDOffcanvasContext` hook. The payload type of the offcanvas
+The available offcanvas are configured on the `DContextProvider` so that they can
+then be opened with the `useDPortalContext` hook. The payload type of the offcanvas
 is only necessary if payload will be used.
 
 <Source
@@ -130,11 +130,11 @@ import {
 import type { OffcanvasPayloads } from './types';
 
 export function ExampleOffcanvasUsage() {
-  const { openOffcanvas } = useDPortalContext<OffcanvasPayloads>();
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
   return (
     <DButton
       text="Open Offcanvas"
-      onClick={() => openOffcanvas('example', { description: 'from offcanvas payload' })}
+      onClick={() => openPortal('example', { description: 'from offcanvas payload' })}
     />
   );
 }

--- a/stories/hooks/patterns/DOffcanvasPatternExamples.tsx
+++ b/stories/hooks/patterns/DOffcanvasPatternExamples.tsx
@@ -1,11 +1,11 @@
 import {
   DContextProvider,
   useDPortalContext,
-} from '../../src';
-import DButton from '../../src/components/DButton';
-import DOffcanvas from '../../src/components/DOffcanvas/DOffcanvas';
+} from '../../../src';
+import DButton from '../../../src/components/DButton';
+import DOffcanvas from '../../../src/components/DOffcanvas/DOffcanvas';
 
-import type { PortalProps } from '../../src';
+import type { PortalProps } from '../../../src';
 
 type OffcanvasPayloads = {
   example: {
@@ -48,7 +48,7 @@ function ExampleOffcanvasUsage() {
   return (
     <DButton
       text="Open Offcanvas"
-      onClick={() => openPortal('example', { description: 'from portal payload' })}
+      onClick={() => openPortal('example', { description: 'from offcanvas payload' })}
     />
   );
 }

--- a/stories/hooks/useDPortalContext.mdx
+++ b/stories/hooks/useDPortalContext.mdx
@@ -95,7 +95,7 @@ Consumers set these on `DContextProvider` — never use `DPortalContextProvider`
 | Property | Type | Description |
 |---|---|---|
 | `portalName` | `string` | DOM element id used as the portal mount point. |
-| `availablePortals` | `{ [K in keyof T]: FC<PortalProps<T[K]>> }` | Map of portal name to the component that renders it. |
+| `availablePortals?` | `{ [K in keyof T]: FC<PortalProps<T[K]>> }` | Map of portal name to the component that renders it. Optional on `DContextProvider`, but calling `openPortal` without a registered component for the given portal name will throw at runtime. |
 | `children` | `ReactNode` | React children to render inside the context. |
 
 ## Basic Usage

--- a/stories/hooks/useDPortalContext.mdx
+++ b/stories/hooks/useDPortalContext.mdx
@@ -73,7 +73,7 @@ export function App() {
 
 | Property | Type | Description |
 |---|---|---|
-| `openPortal` | `<K extends keyof T>(name: K, payload: T[K]) => void` | Pushes a named portal onto the stack, rendering its registered component with the given payload. TypeScript correlates `name` with the expected `payload` shape. |
+| `openPortal` | `<K extends keyof T & string>(name: K, payload: T[K]) => void` | Pushes a named portal onto the stack, rendering its registered component with the given payload. TypeScript correlates `name` with the expected `payload` shape. |
 | `closePortal` | `() => void` | Pops the topmost portal off the stack, closing it. |
 | `stack` | `PortalStackEntry<T>[]` | Currently open portals, ordered from oldest (bottom) to newest (top). Each entry exposes `name` and `payload` — use `stack.length` to check if any portal is open. |
 

--- a/stories/hooks/useDPortalContext.mdx
+++ b/stories/hooks/useDPortalContext.mdx
@@ -190,6 +190,8 @@ Ensure your component is rendered inside a `DContextProvider`:
 
 <Source
   code={`
+import { useDPortalContext, DContextProvider } from '@dynamic-framework/ui-react';
+
 // ✗ Wrong — hook called at the root, outside DContextProvider
 export function App() {
   const { openPortal } = useDPortalContext(); // throws!

--- a/stories/hooks/useDPortalContext.mdx
+++ b/stories/hooks/useDPortalContext.mdx
@@ -75,7 +75,7 @@ export function App() {
 |---|---|---|
 | `openPortal` | `<K extends keyof T>(name: K, payload: T[K]) => void` | Pushes a named portal onto the stack, rendering its registered component with the given payload. TypeScript correlates `name` with the expected `payload` shape. |
 | `closePortal` | `() => void` | Pops the topmost portal off the stack, closing it. |
-| `stack` | `Array<{ name: string; payload: T[keyof T] }>` | Currently open portals, ordered from oldest (bottom) to newest (top). |
+| `stack` | `PortalStackEntry<T>[]` | Currently open portals, ordered from oldest (bottom) to newest (top). Each entry exposes `name` and `payload` — use `stack.length` to check if any portal is open. |
 
 ### `PortalProps<P>`
 

--- a/stories/hooks/useDPortalContext.mdx
+++ b/stories/hooks/useDPortalContext.mdx
@@ -1,0 +1,222 @@
+import { Meta, Source, Unstyled } from "@storybook/addon-docs/blocks";
+
+import {
+  ExamplePortalContextRoot,
+} from "./useDPortalContextExamples";
+
+import DAlert from "../../src/components/DAlert/DAlert";
+
+<Meta title="Design System/Utils/Hooks/useDPortalContext" />
+
+# useDPortalContext
+
+![Shield Badge](https://img.shields.io/badge/Abstraction%20Component-4848b7)
+
+`useDPortalContext` is the primary hook for managing portals — modals, offcanvas panels, and any other
+overlay rendered outside the normal React tree. It provides a stack-based API so multiple portals can
+be layered and closed in LIFO order.
+
+<br />
+
+<Unstyled>
+  <DAlert color="warning">
+    <span>
+      <code>useDPortalContext</code> must be called inside a component tree that
+      is wrapped by <code>DContextProvider</code>. Using it outside of that tree
+      will throw an error at runtime.
+    </span>
+  </DAlert>
+</Unstyled>
+
+## Prerequisites
+
+Before calling `useDPortalContext`, two things must be present in the component tree:
+
+1. **`DContextProvider`** — registers the portal mount point and the available portal components.
+2. A **DOM element** with the `id` matching `portalName` — `DContextProvider` creates this automatically.
+
+```
+DContextProvider  (portalName="appPortal", availablePortals={{ modal: MyModal }})
+└── <YourApp>    ← useDPortalContext() → openPortal('modal', payload)
+```
+
+<Source
+  code={`
+import {
+  DContextProvider,
+} from '@dynamic-framework/ui-react';
+
+import { MyModal } from './MyModal';
+
+import type { MyPayloads } from './types';
+
+export function App() {
+  return (
+    <DContextProvider<MyPayloads>
+      portalName="appPortal"
+      availablePortals={{
+        modal: MyModal,
+      }}
+    >
+      {/* your app content */}
+    </DContextProvider>
+  );
+}
+`}
+  language="tsx"
+  dark
+/>
+
+## API
+
+### Return value
+
+| Property | Type | Description |
+|---|---|---|
+| `openPortal` | `(name: string, payload: T[keyof T]) => void` | Pushes a named portal onto the stack, rendering its registered component with the given payload. |
+| `closePortal` | `() => void` | Pops the topmost portal off the stack, closing it. |
+| `stack` | `PortalStackItem[]` | Currently open portals, ordered from oldest (bottom) to newest (top). |
+
+### `PortalProps<P>`
+
+Props received by every component registered in `availablePortals`. Use
+`PortalProps<Payloads['myPortal']>` to type a specific portal component.
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Portal identifier — matches the key used in `openPortal`. |
+| `payload` | `P` | Data passed via `openPortal`. |
+
+### `PortalContextProps<T>`
+
+Props consumed by `DContextProvider` to configure the portal system.
+Consumers set these on `DContextProvider` — never use `DPortalContextProvider` directly.
+
+| Property | Type | Description |
+|---|---|---|
+| `portalName` | `string` | DOM element id used as the portal mount point. |
+| `availablePortals` | `{ [K in keyof T]: FC<PortalProps<T[K]>> }` | Map of portal name to the component that renders it. |
+| `children` | `ReactNode` | React children to render inside the context. |
+
+## Basic Usage
+
+<Source
+  code={`
+import { useDPortalContext } from '@dynamic-framework/ui-react';
+
+import type { MyPayloads } from './types';
+
+export function OpenModalButton() {
+  const { openPortal } = useDPortalContext<MyPayloads>();
+  return (
+    <button onClick={() => openPortal('modal', { title: 'Hello' })}>
+      Open Modal
+    </button>
+  );
+}
+`}
+  language="tsx"
+  dark
+/>
+
+Closing a portal from inside the portal component:
+
+<Source
+  code={`
+import { DModal, DButton, useDPortalContext } from '@dynamic-framework/ui-react';
+import type { PortalProps } from '@dynamic-framework/ui-react';
+import type { MyPayloads } from './types';
+
+export function MyModal({ payload }: PortalProps<MyPayloads['modal']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DModal name="modal">
+      <DModal.Header onClose={closePortal} showCloseButton>
+        <h5>{payload.title}</h5>
+      </DModal.Header>
+      <DModal.Body>Modal content</DModal.Body>
+    </DModal>
+  );
+}
+`}
+  language="tsx"
+  dark
+/>
+
+## Advanced Typing
+
+Providing the payload type map as a generic argument enables TypeScript to
+enforce the payload shape for each portal name:
+
+<Source
+  code={`
+// types.ts
+export type AppPortalPayloads = {
+  confirm: { message: string };
+  userDetail: { userId: string };
+};
+`}
+  language="tsx"
+  dark
+/>
+
+<Source
+  code={`
+import { useDPortalContext } from '@dynamic-framework/ui-react';
+import type { AppPortalPayloads } from './types';
+
+// TypeScript will validate payload shapes:
+const { openPortal } = useDPortalContext<AppPortalPayloads>();
+openPortal('confirm', { message: 'Are you sure?' });      // ✓
+openPortal('userDetail', { userId: 'abc-123' });          // ✓
+openPortal('confirm', { userId: 'abc-123' });             // ✗ type error
+`}
+  language="tsx"
+  dark
+/>
+
+## Live Example
+
+<Unstyled>
+  <ExamplePortalContextRoot />
+</Unstyled>
+
+## Common Errors
+
+### `useDPortalContext was used outside of DPortalContextProvider`
+
+This error is thrown when `useDPortalContext` is called outside a `DContextProvider` subtree.
+Ensure your component is rendered inside a `DContextProvider`:
+
+<Source
+  code={`
+// ✗ Wrong — hook called at the root, outside DContextProvider
+export function App() {
+  const { openPortal } = useDPortalContext(); // throws!
+  return <DContextProvider>...</DContextProvider>;
+}
+
+// ✓ Correct — component that uses the hook is inside DContextProvider
+export function App() {
+  return (
+    <DContextProvider portalName="app" availablePortals={{}}>
+      <MyComponent />  {/* useDPortalContext() is safe here */}
+    </DContextProvider>
+  );
+}
+`}
+  language="tsx"
+  dark
+/>
+
+### Portal component not found
+
+If `openPortal` is called with a name not registered in `availablePortals`, an error is thrown.
+Make sure every portal name you pass to `openPortal` has a matching entry in `availablePortals`.
+
+## Patterns
+
+For full implementation patterns see:
+
+- [Design System/Patterns/Modal](?path=/docs/design-system-patterns-modal--docs) — modal pattern with `DModal`
+- [Design System/Patterns/Offcanvas](?path=/docs/design-system-patterns-offcanvas--docs) — offcanvas pattern with `DOffcanvas`

--- a/stories/hooks/useDPortalContext.mdx
+++ b/stories/hooks/useDPortalContext.mdx
@@ -73,9 +73,9 @@ export function App() {
 
 | Property | Type | Description |
 |---|---|---|
-| `openPortal` | `(name: string, payload: T[keyof T]) => void` | Pushes a named portal onto the stack, rendering its registered component with the given payload. |
+| `openPortal` | `<K extends keyof T>(name: K, payload: T[K]) => void` | Pushes a named portal onto the stack, rendering its registered component with the given payload. TypeScript correlates `name` with the expected `payload` shape. |
 | `closePortal` | `() => void` | Pops the topmost portal off the stack, closing it. |
-| `stack` | `PortalStackItem[]` | Currently open portals, ordered from oldest (bottom) to newest (top). |
+| `stack` | `Array<{ name: string; payload: T[keyof T] }>` | Currently open portals, ordered from oldest (bottom) to newest (top). |
 
 ### `PortalProps<P>`
 

--- a/stories/hooks/useDPortalContextExamples.tsx
+++ b/stories/hooks/useDPortalContextExamples.tsx
@@ -1,0 +1,62 @@
+import {
+  DContextProvider,
+  useDPortalContext,
+} from '../../src';
+import DButton from '../../src/components/DButton';
+import DModal from '../../src/components/DModal/DModal';
+
+import type { PortalProps } from '../../src';
+
+type ExamplePayloads = {
+  info: {
+    message: string;
+  };
+};
+
+function InfoModal({ payload }: PortalProps<ExamplePayloads['info']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DModal
+      name="info"
+      centered
+      staticBackdrop={false}
+    >
+      <DModal.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Information</h5>
+      </DModal.Header>
+      <DModal.Body className="py-3 px-5">
+        <p>{payload.message}</p>
+      </DModal.Body>
+      <DModal.Footer>
+        <DButton
+          text="Close"
+          className="d-grid"
+          onClick={() => closePortal()}
+        />
+      </DModal.Footer>
+    </DModal>
+  );
+}
+
+function OpenModalButton() {
+  const { openPortal } = useDPortalContext<ExamplePayloads>();
+  return (
+    <DButton
+      text="Open Portal"
+      onClick={() => openPortal('info', { message: 'Hello from useDPortalContext!' })}
+    />
+  );
+}
+
+export function ExamplePortalContextRoot() {
+  return (
+    <DContextProvider<ExamplePayloads>
+      portalName="exampleDPortalContext"
+      availablePortals={{
+        info: InfoModal,
+      }}
+    >
+      <OpenModalButton />
+    </DContextProvider>
+  );
+}


### PR DESCRIPTION
Closes #1038

## Cambios

### `src/` — Tipos y JSDoc
- **`DPortalContext.tsx`**: JSDoc completo en `useDPortalContext`, `PortalContextType`, `PortalContextProps`, `PortalProps`; fix mensaje de error (`useDPortalContext` / `DPortalContextProvider`)
- **`DContext.tsx`**: JSDoc en `DContextProvider`, `useDContext`, `CurrencyProps`, `BreakpointProps`; exporta `IconProps` e `IconMapProps` con JSDoc
- **`contexts/index.ts`**: re-exporta `PortalContextType` y `PortalContextProps`
- **`hooks/index.ts`**: remueve `usePortal` del barrel público (era interno)
- **`hooks/usePortal.ts`**: agrega JSDoc `@internal`

### `scripts/generate-hooks.mjs` — Extractor de API
- Soporta `export function useX()` (named export) y hooks genéricos
- Añade `DPortalContext.tsx` y `DContext.tsx` a `HOOK_FILES`
- Refactoriza `extractHookDoc` → `extractFileDocs` (retorna array, múltiples entradas por archivo)
- Nuevo `processComponentNode` para documentar componentes provider con JSDoc
- Detección de arrays: emite `ElementType[]` en vez de expandir métodos de `Array.prototype`
- Usa `aliasSymbol` para emitir referencias a tipos nombrados (`CurrencyProps`, `BreakpointProps`, etc.) en lugar de expandir inline
- Distingue propiedades callable vs. datos en la sección `returns`
- Extrae tag `@throws` al JSON

### `stories/` — Documentación Storybook
- **Nuevo** `stories/hooks/useDPortalContext.mdx` + `useDPortalContextExamples.tsx`
- **Renombrados** `useModal.mdx` → `patterns/DModalPattern.mdx`, `useOffcanvas.mdx` → `patterns/DOffcanvasPattern.mdx` (+ sus ejemplos)
- Corrige bugs en patrones: `useDModalContext` → `useDPortalContext`, `openOffcanvas` → `openPortal`, `DOffcanvasContextProvider` → `DContextProvider`
- Mueve story de `DContextProvider` a `stories/context/` (`Design System/Context/ContextProvider`)