### PR TITLE
fix(storybook): preserve docs for each release version

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -28,7 +28,10 @@ jobs:
         run: npm run build
       - name: Build storybook
         run: npm run build:storybook
-      - name: Deploy 🚀
+      - name: Extract release version
+        id: version
+        run: echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+      - name: Deploy latest 🚀
         uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,4 +39,13 @@ jobs:
           FOLDER: docs
           CLEAN: true
           TARGET_FOLDER: docs/latest
-          COMMIT_MESSAGE: 'doc: update storybook (tag latest)'
+          COMMIT_MESSAGE: 'doc: update storybook (latest)'
+      - name: Deploy versioned 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: docs
+          FOLDER: docs
+          CLEAN: false
+          TARGET_FOLDER: docs/${{ steps.version.outputs.tag }}
+          COMMIT_MESSAGE: 'doc: update storybook (${{ steps.version.outputs.tag }})'


### PR DESCRIPTION
## Cambios

Modifica `.github/workflows/storybook.yml` para publicar el Storybook en una ruta versionada además de `latest`, siguiendo el mismo patrón que `cdn.yml`.

### Qué cambia

- Se agrega el paso **"Extract release version"** que captura `github.event.release.tag_name` (e.g. `v2.4.0`)
- Se agrega el paso **"Deploy versioned"** que publica en `docs/v{tag}` con `CLEAN: false` — esto preserva los deploys versionados previos
- El paso existente de `docs/latest` se mantiene sin cambios (`CLEAN: true`)

### Resultado después de un release

| URL | Contenido |
|---|---|
| `react.dynamicframework.dev/latest/props.json` | props de la versión más nueva (mutable) |
| `react.dynamicframework.dev/v2.4.0/props.json` | props de v2.4.0 (inmutable) |
| `react.dynamicframework.dev/v2.3.x/props.json` | preservado de releases anteriores |

Closes #1036