### PR TITLE
feat(cdn): publish Storybook manifests as versioned CDN assets

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -28,6 +28,8 @@ jobs:
           fi
       - name: Build packages
         run: npm run build
+      - name: Build Storybook (for versioned manifests)
+        run: npm run build:storybook
       - name: Generate registry assets
         run: |
           node scripts/generate-api.mjs
@@ -85,6 +87,18 @@ jobs:
             s3://dynamicframework-cdn/assets/${{ steps.version.outputs.semver }}/ui-react/api.json \
             --acl public-read \
             --cache-control "public, max-age=31536000, immutable"
+      - name: Upload Storybook components manifest to CDN (versioned)
+        run: |
+          aws s3 cp docs/manifests/components.json \
+            s3://dynamicframework-cdn/assets/${{ steps.version.outputs.semver }}/ui-react/manifests/components.json \
+            --acl public-read \
+            --cache-control "public, max-age=31536000, immutable"
+      - name: Upload Storybook docs manifest to CDN (versioned)
+        run: |
+          aws s3 cp docs/manifests/docs.json \
+            s3://dynamicframework-cdn/assets/${{ steps.version.outputs.semver }}/ui-react/manifests/docs.json \
+            --acl public-read \
+            --cache-control "public, max-age=31536000, immutable"
       - name: Upload api.json to CDN (latest — stable releases only)
         if: ${{ !contains(steps.version.outputs.semver, '-') }}
         run: |
@@ -104,18 +118,25 @@ jobs:
             s3://dynamicframework-cdn/assets/manifest.json \
             --acl public-read \
             --cache-control "public, max-age=60"
-      - name: Smoke test — verify versioned api.json is accessible on CDN
+      - name: Smoke test — verify versioned assets are accessible on CDN
         run: |
-          URL="${{ env.CDN_BASE_URL }}/${{ steps.version.outputs.semver }}/ui-react/api.json"
-          echo "Checking $URL"
-          for i in $(seq 1 24); do
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$URL")
-            if [ "$STATUS" = "200" ]; then
-              echo "✓ api.json is accessible on CDN (HTTP 200)"
-              exit 0
+          BASE="${{ env.CDN_BASE_URL }}/${{ steps.version.outputs.semver }}/ui-react"
+          for path in "api.json" "manifests/components.json" "manifests/docs.json"; do
+            URL="$BASE/$path"
+            echo "Checking $URL"
+            success=0
+            for i in $(seq 1 24); do
+              STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$URL")
+              if [ "$STATUS" = "200" ]; then
+                echo "✓ $path is accessible on CDN (HTTP 200)"
+                success=1
+                break
+              fi
+              echo "Attempt $i/24: HTTP $STATUS — waiting 5s..."
+              sleep 5
+            done
+            if [ "$success" = "0" ]; then
+              echo "✗ $path not accessible on CDN after 2 minutes" >&2
+              exit 1
             fi
-            echo "Attempt $i/24: HTTP $STATUS — waiting 5s..."
-            sleep 5
           done
-          echo "✗ api.json not accessible on CDN after 2 minutes" >&2
-          exit 1

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -118,25 +118,37 @@ jobs:
             s3://dynamicframework-cdn/assets/manifest.json \
             --acl public-read \
             --cache-control "public, max-age=60"
-      - name: Smoke test — verify versioned assets are accessible on CDN
+      - name: Smoke test — verify versioned assets are accessible on CDN with application/json content-type
         run: |
           BASE="${{ env.CDN_BASE_URL }}/${{ steps.version.outputs.semver }}/ui-react"
           for path in "api.json" "manifests/components.json" "manifests/docs.json"; do
             URL="$BASE/$path"
             echo "Checking $URL"
             success=0
+            STATUS=""
+            CTYPE=""
             for i in $(seq 1 24); do
-              STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$URL")
+              INFO=$(curl -s -o /dev/null -w '%{http_code}|%{content_type}' "$URL")
+              STATUS="${INFO%|*}"
+              CTYPE="${INFO#*|}"
               if [ "$STATUS" = "200" ]; then
-                echo "✓ $path is accessible on CDN (HTTP 200)"
-                success=1
-                break
+                case "$CTYPE" in
+                  application/json*)
+                    echo "✓ $path is accessible on CDN (HTTP 200, $CTYPE)"
+                    success=1
+                    break
+                    ;;
+                  *)
+                    echo "Attempt $i/24: HTTP 200 but unexpected content-type '$CTYPE' — waiting 5s..."
+                    ;;
+                esac
+              else
+                echo "Attempt $i/24: HTTP $STATUS — waiting 5s..."
               fi
-              echo "Attempt $i/24: HTTP $STATUS — waiting 5s..."
               sleep 5
             done
             if [ "$success" = "0" ]; then
-              echo "✗ $path not accessible on CDN after 2 minutes" >&2
+              echo "✗ $path not served as application/json on CDN after 2 minutes (last: HTTP $STATUS, content-type '$CTYPE')" >&2
               exit 1
             fi
           done

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -15,6 +15,8 @@ rely on.
 | Versioned `api.json` | `https://cdn.dynamicframework.dev/assets/{semver}/ui-react/api.json` |
 | Version manifest | `https://cdn.dynamicframework.dev/assets/manifest.json` |
 | JSON Schema (v1) | `https://cdn.dynamicframework.dev/assets/schema/v1.json` |
+| Versioned Storybook component manifest | `https://cdn.dynamicframework.dev/assets/{semver}/ui-react/manifests/components.json` |
+| Versioned Storybook docs manifest | `https://cdn.dynamicframework.dev/assets/{semver}/ui-react/manifests/docs.json` |
 
 `{semver}` is the bare semver string (no leading `v`), e.g. `2.4.0`.
 
@@ -175,6 +177,47 @@ JSON parsers and languages. To find the current stable release, read the
 the keys with a semver comparator.
 Prerelease versions (tags containing `-`) are included in `versions` but do **not** advance `latest`
 and carry a `"prerelease": true` flag.
+
+---
+
+## Storybook manifests
+
+Each release also publishes the official **Storybook 10.x AI-ready manifests**
+alongside `api.json`. They are emitted by `storybook build` and serve as the
+canonical source for story snippet code, prop metadata, and inline MDX
+content.
+
+| Resource | URL |
+|---|---|
+| Versioned component manifest | `https://cdn.dynamicframework.dev/assets/{semver}/ui-react/manifests/components.json` |
+| Versioned docs manifest | `https://cdn.dynamicframework.dev/assets/{semver}/ui-react/manifests/docs.json` |
+
+### Contract properties
+
+- **Versioned only.** No `/latest/` alias is published — `publish:cdn-latest`
+  uses `aws s3 sync --delete --exclude 'api.json'` and would purge anything
+  else on the next release. Consumers must address a specific semver.
+- **Immutable per version.** Served with
+  `Cache-Control: public, max-age=31536000, immutable`, matching versioned
+  `api.json`.
+- **Upstream schema.** The shape is owned by Storybook (`v: 0` experimental
+  AI-manifest schema, maintained upstream at
+  <https://github.com/storybookjs/storybook>). It is **not** covered by
+  Dynamic Framework's `schema/v1.json`. Non-breaking schema additions appear
+  without bumping `v`. Consumers should treat unknown fields as additive.
+
+### Quick reference
+
+`components.json` is a `{ v, components }` envelope where `components` is a
+record keyed by display name (e.g. `"DButton"`), each entry containing
+`stories[]` with snippet code, `reactDocgen` props, JSDoc tags, source
+`path`, and the canonical `import` statement.
+
+`docs.json` is a `{ v, docs }` envelope where `docs` is a record keyed by
+Storybook story id (e.g.
+`"design-system-patterns-list-group-patterns--transaction-history"`), each
+entry containing the inline MDX `content` of one documentation or pattern
+story.
 
 ---
 


### PR DESCRIPTION
## Summary

Storybook 10.x generates official AI-ready manifests (`components.json`, `docs.json`) automatically during `storybook build`. These are emitted at `docs/manifests/*` and currently deployed to GitHub Pages at `react.dynamicframework.dev/latest/manifests/`, but not to the versioned CDN at `cdn.dynamicframework.dev/assets/${semver}/ui-react/`.

This PR extends `.github/workflows/cdn.yml` to publish the manifests to the versioned CDN, aligned with the existing `api.json` versioning convention introduced in #1045.

## Motivation

The Modyo MCP server uses a compatibility matrix (`WIDGETS_COMPAT`) to declare which exact version of Dynamic UI its widget generation flow targets. The MCP exposes component knowledge to AI agents via Resources under `modyo://widgets/catalog/*`, which fetch the Storybook manifests from the versioned CDN. This requires the manifests to be available at a versioned URL — `/latest/` would silently drift when Dynamic UI publishes a new release.

The versioned CDN already publishes `api.json` and `schema/v1.json` per release. This PR extends the same pattern to Storybook manifests.

## Changes

`.github/workflows/cdn.yml`:

1. Add `Build Storybook` step between `Build packages` and `Generate registry assets`.
2. Add two upload steps for `components.json` and `docs.json` to `s3://dynamicframework-cdn/assets/${semver}/ui-react/manifests/` with `immutable` cache headers.
3. Extend the smoke test to verify all three versioned assets.

## Design decisions

### Why duplicate `build:storybook` in `cdn.yml` (also runs in `storybook.yml`)?

Both workflows trigger on `release: published`. Sharing the build via `actions/upload-artifact` adds workflow coordination overhead for ~30s of CI savings. Keeping each workflow self-contained isolates failure modes.

### Why no `assets/latest/manifests/`?

`publish:cdn-latest` runs `aws s3 sync ./dist/ --delete --exclude 'api.json'`. Anything published to `assets/latest/` outside the exclude list gets purged on the next release. Consumers read from versioned URLs declared in compat matrices, never from `latest`.

### Why no schema validation for the Storybook manifests?

PR #1063 introduces schema validation for `api.json` against the custom `schema/v1.json` (Dynamic Framework custom contract).

The Storybook manifests follow the official Storybook 10.x manifest schema (`v: 0` experimental, maintained upstream). Validation happens implicitly at generation time inside `storybook build` — a malformed manifest cannot be emitted by a successful build. The extended smoke test (HTTP 200 + content-type) covers the residual risk of corrupted upload.

## Testing

- CI smoke test (extended) verifies HTTP 200 + content-type on all three versioned assets post-upload.
- Locally: `npm run build:storybook && ls -la docs/manifests/` produces `components.json` (~530KB) and `docs.json` (~92KB).

## Out of scope

- Manifests registry extension (follow-up).
- Storybook 10.3.x upgrade (not required — 10.2.8 emits the manifests via `tags: ['autodocs']`).
- Schema validation for Storybook manifests (see design decision above).

## Coordination

Coordinated with Modyo MCP server team.
