### PR TITLE
chore: add TypeScript configuration for Storybook stories

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,7 +83,7 @@
       ],
       "parserOptions": {
         "project": [
-          "./tsconfig.json"
+          "./stories/tsconfig.json"
         ],
         "EXPERIMENTAL_useSourceOfProjectReferenceRedirect": true
       },

--- a/src/components/DPasswordStrengthMeter/DPasswordStrengthMeter.tsx
+++ b/src/components/DPasswordStrengthMeter/DPasswordStrengthMeter.tsx
@@ -25,6 +25,7 @@ type Props = BaseProps & {
   validationMessages?: ValidationMessages;
   enabledChecks?: ValidationCheck[];
   onChange?: (value: string) => void;
+  readonly?: boolean;
 };
 
 const DEFAULT_VALIDATION_MESSAGES: ValidationMessages = {
@@ -51,6 +52,7 @@ export default function DPasswordStrengthMeter({
   style,
   dataAttributes,
   onChange,
+  readonly = false,
 }: Props) {
   const [password, setPassword] = useState<string>(value);
 
@@ -74,6 +76,7 @@ export default function DPasswordStrengthMeter({
         disabled={disabled}
         invalid={invalid}
         onChange={handleChange}
+        readonly={readonly}
       />
 
       <PasswordChecksList

--- a/stories/components/DBadge.stories.tsx
+++ b/stories/components/DBadge.stories.tsx
@@ -34,7 +34,7 @@ The Bootstrap documentation provides details on the default [Badge CSS Variables
   },
   argTypes: {
     size: {
-      control: { type: 'dropdown' },
+      control: 'select',
       options: [undefined, 'sm', 'md', 'lg'],
       table: { category: 'Appearance' },
       description: 'Badge size',
@@ -144,7 +144,7 @@ export const ResponsiveSizes: Story = {
       <DBadge text="ResponsiveObj" size={{ xs: 'sm', md: 'md', xl: 'lg' }} color="warning" />
     </div>
   ),
-  decorators: (Story: Story) => (
+  decorators: (Story) => (
     <DContextProvider>
       <Story />
     </DContextProvider>

--- a/stories/components/DCreditCard.stories.tsx
+++ b/stories/components/DCreditCard.stories.tsx
@@ -107,7 +107,7 @@ const defaultCard = {
   name: 'John Doe',
   number: '**** **** **** 1234',
   brand: 'visa',
-};
+} as const;
 
 export const Default: Story = {
   render: (args) => (

--- a/stories/components/DDataStateWrapper.stories.tsx
+++ b/stories/components/DDataStateWrapper.stories.tsx
@@ -319,7 +319,7 @@ export const CustomTemplates: Story = {
           {...args}
           isLoading={state.isLoading}
           isError={state.isError}
-          data={state.data as unknown[]}
+          data={state.data}
         />
       </div>
     );

--- a/stories/components/DSelect.stories.tsx
+++ b/stories/components/DSelect.stories.tsx
@@ -408,11 +408,6 @@ To understand in more detail the aspects covered by this component, review the f
       description: 'Custom styles for the component',
       table: { category: 'Appearance' },
     },
-    color: {
-      control: 'object',
-      description: 'Custom color for the component',
-      table: { category: 'Appearance' },
-    },
     'aria-label': {
       control: 'text',
       description: 'ARIA label for the component',

--- a/stories/components/DTabs.stories.tsx
+++ b/stories/components/DTabs.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { Meta, StoryObj } from '@storybook/react-vite';
 
+import { CSSProperties } from 'react';
 import DTabs from '../../src/components/DTabs';
 import DBox from '../../src/components/DBox';
 import { PREFIX_BS } from '../../src/components/config';
@@ -149,7 +150,7 @@ export const Default: Story = {
               style={{
                 '--bs-chip-font-size': '10px',
                 lineHeight: 1,
-              }}
+              } as CSSProperties}
               className="p-1"
               text="2"
             />

--- a/stories/components/DTooltip.stories.tsx
+++ b/stories/components/DTooltip.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 
 import { PREFIX_BS } from '../../src/components/config';
 import DTooltip from '../../src/components/DTooltip/DTooltip';
-import { THEMES } from '../config/constants';
 
 const config: Meta<typeof DTooltip> = {
   title: 'Design System/Components/Tooltip',
@@ -69,16 +68,6 @@ The Bootstrap documentation provides details on the default [Tooltip CSS Variabl
       control: 'text',
       table: { category: 'Appearance' },
     },
-    color: {
-      control: 'select',
-      type: 'string',
-      options: THEMES,
-      table: {
-        defaultValue: { summary: 'primary' },
-        category: 'Appearance',
-      },
-      description: 'The color to use.',
-    },
     Component: {
       defaultValue: 'Link',
       type: 'string',
@@ -114,7 +103,6 @@ export const Top: Story = {
     withClick: false,
     withFocus: false,
     open: true,
-    color: 'dark',
   },
 };
 
@@ -127,7 +115,6 @@ export const Right: Story = {
     withClick: false,
     withFocus: false,
     open: false,
-    color: 'secondary',
   },
 };
 
@@ -140,7 +127,6 @@ export const Bottom: Story = {
     withClick: false,
     withFocus: false,
     open: false,
-    color: 'secondary',
   },
 };
 
@@ -153,7 +139,6 @@ export const Left: Story = {
     withClick: false,
     withFocus: false,
     open: false,
-    color: 'secondary',
   },
 };
 
@@ -167,7 +152,6 @@ export const SmallTop: Story = {
     withFocus: false,
     open: false,
     size: 'sm',
-    color: 'secondary',
   },
 };
 
@@ -181,7 +165,6 @@ export const SmallRight: Story = {
     withFocus: false,
     open: false,
     size: 'sm',
-    color: 'secondary',
   },
 };
 
@@ -195,7 +178,6 @@ export const SmallBottom: Story = {
     withFocus: false,
     open: false,
     size: 'sm',
-    color: 'secondary',
   },
 };
 
@@ -209,7 +191,6 @@ export const SmallLeft: Story = {
     withFocus: false,
     open: false,
     size: 'sm',
-    color: 'secondary',
   },
 };
 
@@ -223,7 +204,6 @@ export const LargeTop: Story = {
     withFocus: false,
     open: false,
     size: 'lg',
-    color: 'secondary',
   },
 };
 
@@ -237,7 +217,6 @@ export const LargeRight: Story = {
     withFocus: false,
     open: false,
     size: 'lg',
-    color: 'secondary',
   },
 };
 
@@ -251,7 +230,6 @@ export const LargeBottom: Story = {
     withFocus: false,
     open: false,
     size: 'lg',
-    color: 'secondary',
   },
 };
 
@@ -265,7 +243,6 @@ export const LargeLeft: Story = {
     withFocus: false,
     open: false,
     size: 'lg',
-    color: 'secondary',
   },
 };
 
@@ -279,6 +256,5 @@ export const LargeText: Story = {
     withFocus: false,
     open: false,
     size: 'lg',
-    color: 'secondary',
   },
 };

--- a/stories/patterns/DashboardView.stories.tsx
+++ b/stories/patterns/DashboardView.stories.tsx
@@ -95,7 +95,7 @@ const SUMMARY = [
 ];
 
 const generateChartData = () => {
-  const data = [];
+  const data: { time: string; value1: number; value2: number }[] = [];
   let value1 = 100;
   let value2 = 120;
   for (let i = 0; i < 30; i++) {
@@ -111,7 +111,7 @@ const generateChartData = () => {
 };
 
 const generateTaskChartData = () => {
-  const data = [];
+  const data: { time: string; value: number }[] = [];
   let value = Math.random() * 50 + 50; // Start between 50 and 100
   for (let i = 0; i < 10; i++) {
     data.push({

--- a/stories/tsconfig.json
+++ b/stories/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.storybook/tsconfig.json"
+}

--- a/stories/typings.d.ts
+++ b/stories/typings.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mdx' {
+  const content: React.ComponentType;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,10 @@
   },
   "include": [
     "src",
-    "stories",
     "@types"
+  ],
+  "exclude": [
+    "stories"
   ],
   "compileOnSave": false,
   "buildOnSave": false


### PR DESCRIPTION
Introduce a separate TypeScript configuration for Storybook stories, ensuring they are excluded from the main TypeScript configuration. Update various story components for improved configuration and add a readonly prop to the DPasswordStrengthMeter component.