### PR TITLE
chore(docs): move mobile patterns to dedicated folder and update story sort order

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -63,6 +63,11 @@ const config: Preview = {
             'Components',
             '*'
           ],
+          'Patterns',
+          [
+            'Mobile',
+            '*'
+          ],
         ],
       },
     },

--- a/stories/patterns/mobile/MobileBottomSheetPatterns.stories.tsx
+++ b/stories/patterns/mobile/MobileBottomSheetPatterns.stories.tsx
@@ -11,9 +11,9 @@ import {
   DOffcanvas,
   type PortalProps,
   useDPortalContext,
-} from '../../src';
+} from '../../../src';
 
-import DocsTemplate from './docs/Template.mdx';
+import DocsTemplate from '../docs/Template.mdx';
 
 type AccountActionsPayloads = {
   accountActions: {
@@ -44,7 +44,7 @@ const bottomSheetStyle = {
 } as const;
 
 const meta: Meta<typeof DBox> = {
-  title: 'Mobile Patterns/Mobile Bottom Sheets',
+  title: 'Patterns/Mobile/Bottom Sheets',
   component: DBox,
   parameters: {
     docs: {

--- a/stories/patterns/mobile/MobileDockMenus.stories.tsx
+++ b/stories/patterns/mobile/MobileDockMenus.stories.tsx
@@ -12,9 +12,9 @@ import {
   DButtonIcon,
   DDropdown,
   DIcon,
-} from '../../src';
+} from '../../../src';
 
-import DocsTemplate from './docs/Template.mdx';
+import DocsTemplate from '../docs/Template.mdx';
 
 type DockItem = {
   id: string;
@@ -65,7 +65,7 @@ const TEXT_DOCK_ITEMS: TextDockItem[] = [
 ];
 
 const meta: Meta<typeof DBox> = {
-  title: 'Mobile Patterns/Mobile Dock Menus',
+  title: 'Patterns/Mobile/Dock Menus',
   component: DBox,
   parameters: {
     docs: {
@@ -559,7 +559,7 @@ function ScrollDockWithGradient() {
   useEffect(() => {
     const element = scrollRef.current;
     if (!element) {
-      return () => {};
+      return () => { };
     }
 
     const updateFadeState = () => {

--- a/stories/patterns/mobile/MobileListItemSwipeActions.stories.tsx
+++ b/stories/patterns/mobile/MobileListItemSwipeActions.stories.tsx
@@ -9,10 +9,10 @@ import {
   DDropdown,
   DIcon,
   DListGroup,
-} from '../../src';
+} from '../../../src';
 
-import DocsTemplate from './docs/Template.mdx';
-import { useSwipeableRows } from './hooks/useSwipeableRows';
+import DocsTemplate from '../docs/Template.mdx';
+import { useSwipeableRows } from '../hooks/useSwipeableRows';
 
 type SwipeListItem = {
   id: string;
@@ -49,7 +49,7 @@ const SWIPE_LIST_ITEMS: SwipeListItem[] = [
 ];
 
 const meta: Meta<typeof DBox> = {
-  title: 'Mobile Patterns/List Item Swipe Actions',
+  title: 'Patterns/Mobile/List Item Swipe Actions',
   component: DBox,
   parameters: {
     docs: {

--- a/stories/patterns/mobile/MobileListPatterns.stories.tsx
+++ b/stories/patterns/mobile/MobileListPatterns.stories.tsx
@@ -12,9 +12,9 @@ import {
   DOffcanvas,
   type PortalProps,
   useDPortalContext,
-} from '../../src';
+} from '../../../src';
 
-import DocsTemplate from './docs/Template.mdx';
+import DocsTemplate from '../docs/Template.mdx';
 
 type Story = StoryObj<typeof DBox>;
 
@@ -107,7 +107,7 @@ const bottomSheetStyle = {
 } as const;
 
 const meta: Meta<typeof DBox> = {
-  title: 'Mobile Patterns/Mobile Lists',
+  title: 'Patterns/Mobile/Lists',
   component: DBox,
   parameters: {
     docs: {

--- a/stories/patterns/mobile/MobileWelcomeCarouselPatterns.stories.tsx
+++ b/stories/patterns/mobile/MobileWelcomeCarouselPatterns.stories.tsx
@@ -6,9 +6,9 @@ import {
   DButton,
   DCarousel,
   DIcon,
-} from '../../src';
+} from '../../../src';
 
-import DocsTemplate from './docs/Template.mdx';
+import DocsTemplate from '../docs/Template.mdx';
 
 type OnboardingSlide = {
   id: string;
@@ -230,7 +230,7 @@ function WelcomeOnboardingSplitActionsExample() {
 }`;
 
 const meta: Meta<typeof DBox> = {
-  title: 'Mobile Patterns/Mobile Welcome Carousel',
+  title: 'Patterns/Mobile/Welcome Carousel',
   component: DBox,
   parameters: {
     docs: {


### PR DESCRIPTION
Organize mobile patterns into a specific folder and adjust the story sort order to include a section for mobile patterns.

`components.json `

<img width="663" height="323" alt="image" src="https://github.com/user-attachments/assets/d4f8672f-d9c8-417e-9ada-56a6e0b5bd39" />
