### PR TITLE
feat(DOffcanvas): support responsive openFrom, width and height

### DIFF
--- a/src/components/DOffcanvas/DOffcanvas.spec.tsx
+++ b/src/components/DOffcanvas/DOffcanvas.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DOffcanvas from '.';
+import { DContextProvider } from '../../contexts/DContext';
 
 jest.mock('../../contexts', () => ({
   useDContext: () => ({
@@ -18,6 +19,52 @@ jest.mock('../../contexts', () => ({
     },
   }),
 }));
+
+// Matches the DS default Bootstrap breakpoints, so `DContextProvider`'s
+// `useLayoutEffect` (which reads `--bs-breakpoint-*` CSS variables) resolves
+// the same breakpoints used in a real browser.
+jest.mock('../../utils/getCssVariable', () => ({
+  __esModule: true,
+  default: (name: string) => {
+    if (name.includes('xxl')) return '1400px';
+    if (name.includes('xl')) return '1200px';
+    if (name.includes('lg')) return '992px';
+    if (name.includes('md')) return '768px';
+    if (name.includes('sm')) return '576px';
+    if (name.includes('xs')) return '0px';
+    return '';
+  },
+}));
+
+const BREAKPOINTS_WIDTH: Record<string, number> = {
+  xs: 0, sm: 576, md: 768, lg: 992, xl: 1200, xxl: 1400,
+};
+
+// Simulates a real viewport width against `(min-width: <n>px)` media queries,
+// so `useMediaBreakpointUp`/`useResponsiveProp` resolve the same way they
+// would in a real browser at that width.
+let currentViewportWidth = 0;
+
+beforeAll(() => {
+  window.matchMedia = jest.fn((query: string) => {
+    const match = /min-width:\s*(\d+)px/.exec(query);
+    const breakpointPx = match ? Number(match[1]) : 0;
+    return {
+      matches: currentViewportWidth >= breakpointPx,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as MediaQueryList;
+  });
+});
+
+beforeEach(() => {
+  currentViewportWidth = 0;
+});
 
 describe('<DOffcanvas />', () => {
   describe('Rendering and Props', () => {
@@ -80,6 +127,57 @@ describe('<DOffcanvas />', () => {
     it('should render with a static backdrop', () => {
       const { container } = render(<DOffcanvas name="test" staticBackdrop />);
       expect(container.firstChild).toHaveAttribute('data-bs-backdrop', 'static');
+    });
+
+    it('should resolve responsive openFrom based on the current breakpoint', () => {
+      currentViewportWidth = BREAKPOINTS_WIDTH.lg;
+      const { container } = render(
+        <DContextProvider>
+          <DOffcanvas name="test" openFrom={{ xs: 'bottom', md: 'end', lg: 'top' }} />
+        </DContextProvider>,
+      );
+      expect(container.firstChild).toHaveClass('offcanvas-top');
+      expect(container.firstChild).not.toHaveClass('offcanvas-bottom');
+      expect(container.firstChild).not.toHaveClass('offcanvas-end');
+    });
+
+    it('should fall back to "end" when no breakpoint in the responsive openFrom object matches', () => {
+      currentViewportWidth = BREAKPOINTS_WIDTH.xs;
+      const { container } = render(
+        <DContextProvider>
+          <DOffcanvas name="test" openFrom={{ md: 'top', lg: 'start' }} />
+        </DContextProvider>,
+      );
+      expect(container.firstChild).toHaveClass('offcanvas-end');
+    });
+
+    it('should inject --bs-offcanvas-width/height CSS variables when width/height are provided', () => {
+      const { container } = render(
+        <DOffcanvas name="test" openFrom="end" width="320px" height="50vh" />,
+      );
+      expect(container.firstChild).toHaveStyle({
+        '--bs-offcanvas-width': '320px',
+        '--bs-offcanvas-height': '50vh',
+      });
+    });
+
+    it('should resolve responsive width/height based on the current breakpoint', () => {
+      currentViewportWidth = BREAKPOINTS_WIDTH.md;
+      const { container } = render(
+        <DContextProvider>
+          <DOffcanvas
+            name="test"
+            openFrom="end"
+            width={{ xs: '100%', md: '320px' }}
+          />
+        </DContextProvider>,
+      );
+      expect(container.firstChild).toHaveStyle({ '--bs-offcanvas-width': '320px' });
+    });
+
+    it('should not set --bs-offcanvas-width/height when width/height are not provided', () => {
+      const { container } = render(<DOffcanvas name="test" openFrom="end" />);
+      expect(container.firstChild).not.toHaveStyle({ '--bs-offcanvas-width': '400px' });
     });
 
     it('should render a scrollable offcanvas', () => {

--- a/src/components/DOffcanvas/DOffcanvas.tsx
+++ b/src/components/DOffcanvas/DOffcanvas.tsx
@@ -13,11 +13,13 @@ import DOffcanvasFooter from './components/DOffcanvasFooter';
 
 import type { BaseProps, OffcanvasPositionToggleFrom } from '../interface';
 
+type OffcanvasResponsivePlacement = Partial<Record<'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl', OffcanvasPositionToggleFrom>>;
+
 type Props = BaseProps & PropsWithChildren<{
   name: string;
   staticBackdrop?: boolean;
   scrollable?: boolean;
-  openFrom?: OffcanvasPositionToggleFrom | ResponsiveProp;
+  openFrom?: OffcanvasPositionToggleFrom | OffcanvasResponsivePlacement;
   /**
    * Overrides the offcanvas size on the `start`/`end` placements (defaults to `400px`).
    * Accepts any CSS length (e.g. `'320px'`, `'50vw'`, `'100%'`) or a `ResponsiveProp` object.
@@ -77,11 +79,16 @@ function DOffcanvas(
     dataAttributes,
   }: Props,
 ) {
-  // Responsive openFrom/width/height resolution using useResponsiveProp
-  const { responsivePropValue } = useResponsiveProp(true);
+  // Only subscribe to breakpoint-change listeners when a responsive object is
+  // actually provided, avoiding unnecessary matchMedia subscriptions for the
+  // common case of plain string values.
+  const hasResponsiveProp = typeof openFrom === 'object'
+    || typeof width === 'object'
+    || typeof height === 'object';
+  const { responsivePropValue } = useResponsiveProp(hasResponsiveProp);
   const resolvedOpenFrom = useMemo((): OffcanvasPositionToggleFrom => {
     if (typeof openFrom === 'string') return openFrom;
-    return (responsivePropValue(openFrom) as OffcanvasPositionToggleFrom) ?? 'end';
+    return (responsivePropValue(openFrom) as OffcanvasPositionToggleFrom | undefined) ?? 'end';
   }, [responsivePropValue, openFrom]);
   const resolvedWidth = useMemo(() => {
     if (!width) return undefined;

--- a/src/components/DOffcanvas/DOffcanvas.tsx
+++ b/src/components/DOffcanvas/DOffcanvas.tsx
@@ -1,9 +1,11 @@
 import classNames from 'classnames';
 import { motion, type Transition, type Variants } from 'framer-motion';
 
-import type { PropsWithChildren } from 'react';
+import { useMemo, type PropsWithChildren } from 'react';
 
 import { PREFIX_BS } from '../config';
+
+import { useResponsiveProp, ResponsiveProp } from '../../hooks/useResponsiveProp';
 
 import DOffcanvasHeader from './components/DOffcanvasHeader';
 import DOffcanvasBody from './components/DOffcanvasBody';
@@ -15,7 +17,17 @@ type Props = BaseProps & PropsWithChildren<{
   name: string;
   staticBackdrop?: boolean;
   scrollable?: boolean;
-  openFrom?: OffcanvasPositionToggleFrom;
+  openFrom?: OffcanvasPositionToggleFrom | ResponsiveProp;
+  /**
+   * Overrides the offcanvas size on the `start`/`end` placements (defaults to `400px`).
+   * Accepts any CSS length (e.g. `'320px'`, `'50vw'`, `'100%'`) or a `ResponsiveProp` object.
+   */
+  width?: string | ResponsiveProp;
+  /**
+   * Overrides the offcanvas size on the `top`/`bottom` placements (defaults to `100%`).
+   * Accepts any CSS length (e.g. `'50vh'`, `'320px'`) or a `ResponsiveProp` object.
+   */
+  height?: string | ResponsiveProp;
   transition?: Transition;
 }>;
 
@@ -58,29 +70,50 @@ function DOffcanvas(
     staticBackdrop,
     scrollable,
     openFrom = 'end',
+    width,
+    height,
     transition,
     children,
     dataAttributes,
   }: Props,
 ) {
+  // Responsive openFrom/width/height resolution using useResponsiveProp
+  const { responsivePropValue } = useResponsiveProp(true);
+  const resolvedOpenFrom = useMemo((): OffcanvasPositionToggleFrom => {
+    if (typeof openFrom === 'string') return openFrom;
+    return (responsivePropValue(openFrom) as OffcanvasPositionToggleFrom) ?? 'end';
+  }, [responsivePropValue, openFrom]);
+  const resolvedWidth = useMemo(() => {
+    if (!width) return undefined;
+    if (typeof width === 'string') return width;
+    return responsivePropValue(width);
+  }, [responsivePropValue, width]);
+  const resolvedHeight = useMemo(() => {
+    if (!height) return undefined;
+    if (typeof height === 'string') return height;
+    return responsivePropValue(height);
+  }, [responsivePropValue, height]);
+
   return (
     <motion.div
       className={classNames(
         'offcanvas portal show',
         {
-          [`offcanvas-${openFrom}`]: openFrom,
+          [`offcanvas-${resolvedOpenFrom}`]: resolvedOpenFrom,
         },
         className,
       )}
       style={{
         ...style,
         transition: 'none',
+        ...(resolvedWidth && { [`--${PREFIX_BS}offcanvas-width`]: resolvedWidth }),
+        ...(resolvedHeight && { [`--${PREFIX_BS}offcanvas-height`]: resolvedHeight }),
       }}
       id={name}
       tabIndex={-1}
       aria-labelledby={`${name}Label`}
       aria-hidden="false"
-      custom={openFrom}
+      custom={resolvedOpenFrom}
       variants={variants}
       initial="hidden"
       animate="visible"

--- a/src/style/abstracts/variables/_offcanvas.scss
+++ b/src/style/abstracts/variables/_offcanvas.scss
@@ -15,3 +15,11 @@ $offcanvas-separator-margin-x: var(--#{$prefix}ref-spacer-4) !default;
 
 $offcanvas-bg-color: var(--#{$prefix}white) !default;
 // scss-docs-end offcanvas-variables
+
+// custom
+// Bootstrap's default is 30vh, which cuts off top/bottom offcanvas content
+// (e.g. mobile bottom-sheet placements) and forces an inner scroll. Cover the
+// full viewport height instead, relying on `.offcanvas-body`'s own
+// `overflow-y: auto` to scroll long content while header/footer stay fixed.
+$offcanvas-vertical-height: 100% !default;
+// end custom

--- a/stories/components/DOffcanvas.stories.tsx
+++ b/stories/components/DOffcanvas.stories.tsx
@@ -50,6 +50,41 @@ const config: Meta<typeof DOffcanvas> = {
       type: 'boolean',
       table: { category: 'Behavior' },
     },
+    transition: {
+      table: { category: 'Appearance' },
+    },
+    openFrom: {
+      control: 'object',
+      table: {
+        category: 'Appearance',
+        type: {
+          summary: "'start' | 'end' | 'top' | 'bottom' | ResponsiveProp",
+        },
+      },
+      description:
+        'Side the offcanvas opens from. Accepts a single value or a `ResponsiveProp` object '
+        + "(e.g. `{ xs: 'bottom', md: 'end' }`) to change placement per breakpoint.",
+    },
+    width: {
+      control: 'text',
+      table: {
+        category: 'Appearance',
+        type: { summary: 'string | ResponsiveProp' },
+      },
+      description:
+        'Overrides the size on `start`/`end` placements (defaults to `400px`). Accepts any '
+        + "CSS length (e.g. `'320px'`, `'100%'`) or a `ResponsiveProp` object.",
+    },
+    height: {
+      control: 'text',
+      table: {
+        category: 'Appearance',
+        type: { summary: 'string | ResponsiveProp' },
+      },
+      description:
+        'Overrides the size on `top`/`bottom` placements (defaults to `100%`). Accepts any '
+        + "CSS length (e.g. `'50vh'`, `'320px'`) or a `ResponsiveProp` object.",
+    },
   },
 };
 
@@ -435,6 +470,171 @@ export const OnlyBody: Story = {
     scrollable: false,
     openFrom: 'end',
   },
+};
+
+function ResponsiveFiltersOffcanvas({ name }: PortalProps<OffcanvasPayloads['filters']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DOffcanvas
+      name={name}
+      staticBackdrop={false}
+      scrollable={false}
+      openFrom={{
+        xs: 'bottom', sm: 'start', md: 'end', lg: 'top',
+      }}
+    >
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Advanced filters</h5>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body>
+        <p>Offcanvas body</p>
+        <small>
+          Resize the viewport: opens from
+          {' '}
+          <code>bottom</code>
+          {' '}
+          below the
+          {' '}
+          <code>md</code>
+          {' '}
+          breakpoint and from
+          {' '}
+          <code>end</code>
+          {' '}
+          from
+          {' '}
+          <code>md</code>
+          {' '}
+          up.
+        </small>
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer>
+        <DButton
+          text="Cancel"
+          color="secondary"
+          variant="outline"
+          onClick={() => closePortal()}
+        />
+        <DButton
+          text="Ok"
+          onClick={() => closePortal()}
+        />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function OpenResponsiveFiltersOffcanvasButton() {
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
+  return (
+    <DButton
+      text="Open Responsive Offcanvas"
+      onClick={() => openPortal('filters', { description: 'Payload passed via openPortal.' })}
+    />
+  );
+}
+
+export const ResponsivePlacement: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '400px' }} className="d-flex justify-content-center align-items-center">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`openFrom` accepts a `ResponsiveProp` object so the placement can change per breakpoint '
+          + "(e.g. `{ xs: 'bottom', md: 'end' }`), instead of a single fixed value. As with any other "
+          + 'offcanvas, it must be registered in `DContextProvider.availablePortals` and opened via '
+          + '`openPortal` — rendering it directly as JSX is not the recommended usage. '
+          + 'Resize the browser window (or Storybook viewport) to see the placement react to the '
+          + 'real breakpoint.',
+      },
+      source: {
+        code: `
+type OffcanvasPayloads = {
+  filters: {
+    description: string;
+  };
+};
+
+function ResponsiveFiltersOffcanvas({ name }: PortalProps<OffcanvasPayloads['filters']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DOffcanvas 
+      name={name} 
+      staticBackdrop={false} 
+      scrollable={false} 
+      openFrom={{
+        xs: 'bottom', sm: 'start', md: 'end', lg: 'top',
+      }}
+    >
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Advanced filters</h5>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body>
+        <p>Offcanvas body</p>
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer>
+        <DButton text="Cancel" color="secondary" variant="outline" onClick={() => closePortal()} />
+        <DButton text="Ok" onClick={() => closePortal()} />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function OpenResponsiveFiltersOffcanvasButton() {
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
+  return (
+    <DButton
+      text="Open Responsive Offcanvas"
+      onClick={() => openPortal('filters', { description: 'Payload passed via openPortal.' })}
+    />
+  );
+}
+
+function App() {
+  return (
+    <DContextProvider<OffcanvasPayloads>
+      portalName="dOffcanvasResponsiveStoryPortal"
+      availablePortals={{ filters: ResponsiveFiltersOffcanvas }}
+    >
+      <OpenResponsiveFiltersOffcanvasButton />
+    </DContextProvider>
+  );
+}
+        `.trim(),
+        language: 'tsx',
+        type: 'code',
+      },
+    },
+  },
+  render: () => (
+    <DContextProvider<OffcanvasPayloads>
+      portalName="dOffcanvasResponsiveStoryPortal"
+      availablePortals={{ filters: ResponsiveFiltersOffcanvas }}
+    >
+      <div className="d-flex flex-column gap-2 align-items-center">
+        <OpenResponsiveFiltersOffcanvasButton />
+        <pre>
+          <code>
+            {JSON.stringify({
+              openFrom:
+              {
+                xs: 'bottom',
+                sm: 'start',
+                md: 'end',
+                lg: 'top',
+              },
+            }, null, 2)}
+          </code>
+        </pre>
+      </div>
+    </DContextProvider>
+  ),
 };
 
 export const WithoutCancelX: Story = {

--- a/stories/components/DOffcanvas.stories.tsx
+++ b/stories/components/DOffcanvas.stories.tsx
@@ -66,7 +66,7 @@ const config: Meta<typeof DOffcanvas> = {
         + "(e.g. `{ xs: 'bottom', md: 'end' }`) to change placement per breakpoint.",
     },
     width: {
-      control: 'text',
+      control: 'object',
       table: {
         category: 'Appearance',
         type: { summary: 'string | ResponsiveProp' },
@@ -76,7 +76,7 @@ const config: Meta<typeof DOffcanvas> = {
         + "CSS length (e.g. `'320px'`, `'100%'`) or a `ResponsiveProp` object.",
     },
     height: {
-      control: 'text',
+      control: 'object',
       table: {
         category: 'Appearance',
         type: { summary: 'string | ResponsiveProp' },
@@ -493,17 +493,31 @@ function ResponsiveFiltersOffcanvas({ name }: PortalProps<OffcanvasPayloads['fil
           {' '}
           <code>bottom</code>
           {' '}
-          below the
+          below
           {' '}
-          <code>md</code>
+          <code>sm</code>
+          , from
           {' '}
-          breakpoint and from
+          <code>start</code>
+          {' '}
+          on
+          {' '}
+          <code>sm</code>
+          , from
           {' '}
           <code>end</code>
           {' '}
-          from
+          on
           {' '}
           <code>md</code>
+          {' '}
+          and from
+          {' '}
+          <code>top</code>
+          {' '}
+          from
+          {' '}
+          <code>lg</code>
           {' '}
           up.
         </small>

--- a/stories/components/DOffcanvas.stories.tsx
+++ b/stories/components/DOffcanvas.stories.tsx
@@ -651,6 +651,330 @@ function App() {
   ),
 };
 
+function ResponsiveWidthOffcanvas({ name }: PortalProps<OffcanvasPayloads['filters']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DOffcanvas
+      name={name}
+      staticBackdrop={false}
+      scrollable={false}
+      openFrom="end"
+      width={{ xs: '100%', sm: '320px', lg: '480px' }}
+    >
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Advanced filters</h5>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body>
+        <p>Offcanvas body</p>
+        <small>
+          Resize the viewport: below
+          {' '}
+          <code>sm</code>
+          {' '}
+          width is
+          {' '}
+          <code>100%</code>
+          , from
+          {' '}
+          <code>sm</code>
+          {' '}
+          it&apos;s
+          {' '}
+          <code>320px</code>
+          , and from
+          {' '}
+          <code>lg</code>
+          {' '}
+          up
+          {' '}
+          <code>480px</code>
+          .
+        </small>
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer>
+        <DButton
+          text="Cancel"
+          color="secondary"
+          variant="outline"
+          onClick={() => closePortal()}
+        />
+        <DButton
+          text="Ok"
+          onClick={() => closePortal()}
+        />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function OpenResponsiveWidthOffcanvasButton() {
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
+  return (
+    <DButton
+      text="Open Responsive Width Offcanvas"
+      onClick={() => openPortal('filters', { description: 'Payload passed via openPortal.' })}
+    />
+  );
+}
+
+export const ResponsiveWidth: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '400px' }} className="d-flex justify-content-center align-items-center">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`width` accepts a `ResponsiveProp` object so the offcanvas width (on `start`/`end` '
+          + "placements) can change per breakpoint (e.g. `{ xs: '100%', md: '320px' }`), instead of a "
+          + 'single fixed value. As with any other offcanvas, it must be registered in '
+          + '`DContextProvider.availablePortals` and opened via `openPortal` — rendering it directly '
+          + 'as JSX is not the recommended usage. Resize the browser window (or Storybook viewport) '
+          + 'to see the width react to the real breakpoint.',
+      },
+      source: {
+        code: `
+type OffcanvasPayloads = {
+  filters: {
+    description: string;
+  };
+};
+
+function ResponsiveWidthOffcanvas({ name }: PortalProps<OffcanvasPayloads['filters']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DOffcanvas
+      name={name}
+      staticBackdrop={false}
+      scrollable={false}
+      openFrom="end"
+      width={{ xs: '100%', sm: '320px', lg: '480px' }}
+    >
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Advanced filters</h5>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body>
+        <p>Offcanvas body</p>
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer>
+        <DButton text="Cancel" color="secondary" variant="outline" onClick={() => closePortal()} />
+        <DButton text="Ok" onClick={() => closePortal()} />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function OpenResponsiveWidthOffcanvasButton() {
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
+  return (
+    <DButton
+      text="Open Responsive Width Offcanvas"
+      onClick={() => openPortal('filters', { description: 'Payload passed via openPortal.' })}
+    />
+  );
+}
+
+function App() {
+  return (
+    <DContextProvider<OffcanvasPayloads>
+      portalName="dOffcanvasResponsiveWidthStoryPortal"
+      availablePortals={{ filters: ResponsiveWidthOffcanvas }}
+    >
+      <OpenResponsiveWidthOffcanvasButton />
+    </DContextProvider>
+  );
+}
+        `.trim(),
+        language: 'tsx',
+        type: 'code',
+      },
+    },
+  },
+  render: () => (
+    <DContextProvider<OffcanvasPayloads>
+      portalName="dOffcanvasResponsiveWidthStoryPortal"
+      availablePortals={{ filters: ResponsiveWidthOffcanvas }}
+    >
+      <div className="d-flex flex-column gap-2 align-items-center">
+        <OpenResponsiveWidthOffcanvasButton />
+        <pre>
+          <code>
+            {JSON.stringify({
+              width: { xs: '100%', sm: '320px', lg: '480px' },
+            }, null, 2)}
+          </code>
+        </pre>
+      </div>
+    </DContextProvider>
+  ),
+};
+
+function ResponsiveHeightOffcanvas({ name }: PortalProps<OffcanvasPayloads['filters']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DOffcanvas
+      name={name}
+      staticBackdrop={false}
+      scrollable={false}
+      openFrom="bottom"
+      height={{ xs: '50vh', md: '75vh', lg: '100%' }}
+    >
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Advanced filters</h5>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body>
+        <p>Offcanvas body</p>
+        <small>
+          Resize the viewport: below
+          {' '}
+          <code>md</code>
+          {' '}
+          height is
+          {' '}
+          <code>50vh</code>
+          , from
+          {' '}
+          <code>md</code>
+          {' '}
+          it&apos;s
+          {' '}
+          <code>75vh</code>
+          , and from
+          {' '}
+          <code>lg</code>
+          {' '}
+          up
+          {' '}
+          <code>100%</code>
+          .
+        </small>
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer>
+        <DButton
+          text="Cancel"
+          color="secondary"
+          variant="outline"
+          onClick={() => closePortal()}
+        />
+        <DButton
+          text="Ok"
+          onClick={() => closePortal()}
+        />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function OpenResponsiveHeightOffcanvasButton() {
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
+  return (
+    <DButton
+      text="Open Responsive Height Offcanvas"
+      onClick={() => openPortal('filters', { description: 'Payload passed via openPortal.' })}
+    />
+  );
+}
+
+export const ResponsiveHeight: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '400px' }} className="d-flex justify-content-center align-items-center">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`height` accepts a `ResponsiveProp` object so the offcanvas height (on `top`/`bottom` '
+          + "placements) can change per breakpoint (e.g. `{ xs: '50vh', md: '100%' }`), instead of a "
+          + 'single fixed value. As with any other offcanvas, it must be registered in '
+          + '`DContextProvider.availablePortals` and opened via `openPortal` — rendering it directly '
+          + 'as JSX is not the recommended usage. Resize the browser window (or Storybook viewport) '
+          + 'to see the height react to the real breakpoint.',
+      },
+      source: {
+        code: `
+type OffcanvasPayloads = {
+  filters: {
+    description: string;
+  };
+};
+
+function ResponsiveHeightOffcanvas({ name }: PortalProps<OffcanvasPayloads['filters']>) {
+  const { closePortal } = useDPortalContext();
+  return (
+    <DOffcanvas
+      name={name}
+      staticBackdrop={false}
+      scrollable={false}
+      openFrom="bottom"
+      height={{ xs: '50vh', md: '75vh', lg: '100%' }}
+    >
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <h5 className="fw-bold">Advanced filters</h5>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body>
+        <p>Offcanvas body</p>
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer>
+        <DButton text="Cancel" color="secondary" variant="outline" onClick={() => closePortal()} />
+        <DButton text="Ok" onClick={() => closePortal()} />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function OpenResponsiveHeightOffcanvasButton() {
+  const { openPortal } = useDPortalContext<OffcanvasPayloads>();
+  return (
+    <DButton
+      text="Open Responsive Height Offcanvas"
+      onClick={() => openPortal('filters', { description: 'Payload passed via openPortal.' })}
+    />
+  );
+}
+
+function App() {
+  return (
+    <DContextProvider<OffcanvasPayloads>
+      portalName="dOffcanvasResponsiveHeightStoryPortal"
+      availablePortals={{ filters: ResponsiveHeightOffcanvas }}
+    >
+      <OpenResponsiveHeightOffcanvasButton />
+    </DContextProvider>
+  );
+}
+        `.trim(),
+        language: 'tsx',
+        type: 'code',
+      },
+    },
+  },
+  render: () => (
+    <DContextProvider<OffcanvasPayloads>
+      portalName="dOffcanvasResponsiveHeightStoryPortal"
+      availablePortals={{ filters: ResponsiveHeightOffcanvas }}
+    >
+      <div className="d-flex flex-column gap-2 align-items-center">
+        <OpenResponsiveHeightOffcanvasButton />
+        <pre>
+          <code>
+            {JSON.stringify({
+              height: { xs: '50vh', md: '75vh', lg: '100%' },
+            }, null, 2)}
+          </code>
+        </pre>
+      </div>
+    </DContextProvider>
+  ),
+};
+
 export const WithoutCancelX: Story = {
   decorators: [
     (Story) => (


### PR DESCRIPTION
## Resumen

Implementa la issue #1108: permite que `openFrom` del `DOffcanvas` reciba un objeto responsive (por breakpoint) además de un único valor fijo, para poder definir, por ejemplo, que el offcanvas abra desde `bottom` en mobile y desde `end` en desktop, sin necesidad de un workaround manual con `useMediaBreakpointUp`.

## Cambios

- **`openFrom` responsive**: ahora acepta `OffcanvasPositionToggleFrom | ResponsiveProp` (ej. `{ xs: 'bottom', md: 'end' }`). Se resuelve reactivamente reutilizando el hook `useResponsiveProp`, ya usado por `DButton`, `DBadge` y `DIconBase` — no se agregó infraestructura nueva. Se mantiene 100% compatible con el uso actual de un solo valor (`openFrom="end"`).
- **`width` / `height` personalizables**: nuevas props opcionales (`string | ResponsiveProp`) para sobrescribir el tamaño fijo por defecto (`400px` de ancho en `start`/`end`, `100%` de alto en `top`/`bottom`), inyectadas como variables CSS `--bs-offcanvas-width` / `--bs-offcanvas-height`. Surgió al revisar que el ancho estaba fijo en `start`/`end` y no era ajustable.
- **Fix de bug relacionado**: en mobile, los placements `top`/`bottom` quedaban cortados con scroll interno porque Bootstrap define por defecto `$offcanvas-vertical-height: 30vh`. Se sobrescribe a `100%` en `_offcanvas.scss` (el `.offcanvas-body` sigue haciendo scroll internamente si el contenido es largo, pero el header/footer ya no quedan cortados).
- **Storybook**: se agregó la story `Responsive Placement`, que muestra `openFrom` como `ResponsiveProp` siguiendo el patrón de uso recomendado (`DContextProvider` + `openPortal`, igual que `Real Usage With Open Portal`), en vez de renderizar el componente directamente.

## Cómo funciona de ahora en adelante

```tsx
<DOffcanvas
  name="filters"
  openFrom={{ xs: 'bottom', sm: 'start', md: 'end', lg: 'top' }}
  width={{ xs: '100%', md: '320px' }}
>
  ...
</DOffcanvas>
```

- Si `openFrom` es un string, se comporta exactamente igual que antes.
- Si es un objeto, se resuelve al breakpoint activo más alto que matchee (mismo criterio que `useResponsiveProp` en el resto del design system), y reacciona en vivo a cambios de tamaño de ventana.
- `width`/`height` son opcionales; si no se pasan, se mantiene el tamaño por defecto de Bootstrap (400px / 100%).

## Verificación

- `eslint` limpio en los archivos modificados.
- `tsc --noEmit` sin errores nuevos.
- `npx jest src/components/DOffcanvas` — 9/9 tests pasan.
- `npm run build:scss` para validar el cambio de `_offcanvas.scss` en el CSS compilado.

Closes #1108