### PR TITLE
feat(DCarousel): add iconArrowLeft/iconArrowRight props for custom arrows

### DIFF
--- a/src/components/DCarousel/DCarousel.spec.tsx
+++ b/src/components/DCarousel/DCarousel.spec.tsx
@@ -166,4 +166,57 @@ describe('<DCarousel />', () => {
       </div>
     `);
   });
+
+  it('Should render custom arrow icons when iconArrowLeft/iconArrowRight are provided', () => {
+    const props: ComponentProps<typeof DCarousel> = {
+      iconArrowLeft: { icon: 'ArrowLeft', color: 'success' },
+      iconArrowRight: { icon: 'ArrowRight', color: 'danger' },
+      children: (
+        <>
+          <DCarousel.Slide>
+            Slide 1
+          </DCarousel.Slide>
+          <DCarousel.Slide>
+            Slide 2
+          </DCarousel.Slide>
+        </>
+      ),
+    };
+
+    const { container } = render(
+      <DCarousel {...props} />,
+    );
+
+    const prevButton = container.querySelector('.splide__arrow--prev');
+    const nextButton = container.querySelector('.splide__arrow--next');
+
+    expect(prevButton?.querySelector('.d-icon.d-icon-color-success')).toBeInTheDocument();
+    expect(nextButton?.querySelector('.d-icon.d-icon-color-danger')).toBeInTheDocument();
+    expect(prevButton).toHaveAttribute('aria-label', 'Previous slide');
+    expect(nextButton).toHaveAttribute('aria-label', 'Next slide');
+  });
+
+  it('Should fall back to the default arrow icon on the side without a custom icon', () => {
+    const props: ComponentProps<typeof DCarousel> = {
+      iconArrowLeft: { icon: 'ArrowLeft' },
+      children: (
+        <>
+          <DCarousel.Slide>
+            Slide 1
+          </DCarousel.Slide>
+          <DCarousel.Slide>
+            Slide 2
+          </DCarousel.Slide>
+        </>
+      ),
+    };
+
+    const { container } = render(
+      <DCarousel {...props} />,
+    );
+
+    const nextButton = container.querySelector('.splide__arrow--next');
+
+    expect(nextButton?.querySelector('svg')).toBeInTheDocument();
+  });
 });

--- a/src/components/DCarousel/DCarousel.spec.tsx
+++ b/src/components/DCarousel/DCarousel.spec.tsx
@@ -219,4 +219,49 @@ describe('<DCarousel />', () => {
 
     expect(nextButton?.querySelector('svg')).toBeInTheDocument();
   });
+
+  it('Should not render arrows when options.arrows is explicitly false, even with icon props', () => {
+    const props: ComponentProps<typeof DCarousel> = {
+      iconArrowLeft: { icon: 'ArrowLeft' },
+      iconArrowRight: { icon: 'ArrowRight' },
+      options: { arrows: false },
+      children: (
+        <>
+          <DCarousel.Slide>
+            Slide 1
+          </DCarousel.Slide>
+          <DCarousel.Slide>
+            Slide 2
+          </DCarousel.Slide>
+        </>
+      ),
+    };
+
+    const { container } = render(
+      <DCarousel {...props} />,
+    );
+
+    expect(container.querySelector('.splide__arrows')).not.toBeInTheDocument();
+  });
+
+  it('Should let a consumer-provided hasTrack take precedence when no icon props are set', () => {
+    const props: ComponentProps<typeof DCarousel> = {
+      hasTrack: false,
+      children: (
+        <div className="splide__track">
+          <ul className="splide__list">
+            <li className="splide__slide">Custom track content</li>
+          </ul>
+        </div>
+      ),
+    };
+
+    const { container } = render(
+      <DCarousel {...props} />,
+    );
+
+    // Splide's own SplideTrack wrapper is not rendered; only the consumer-provided one is.
+    expect(container.querySelectorAll('.splide__track')).toHaveLength(1);
+    expect(container).toHaveTextContent('Custom track content');
+  });
 });

--- a/src/components/DCarousel/DCarousel.tsx
+++ b/src/components/DCarousel/DCarousel.tsx
@@ -1,20 +1,47 @@
-import { Splide } from '@splidejs/react-splide';
+import { Splide, SplideTrack } from '@splidejs/react-splide';
 import classNames from 'classnames';
 import { forwardRef } from 'react';
 
 import type {
+  ComponentProps,
   ForwardedRef,
   PropsWithChildren,
 } from 'react';
 import type { SplideProps } from '@splidejs/react-splide';
 
+import DIcon from '../DIcon';
 import DCarouselSlide from './components/DCarouselSlide';
 
 import type { BaseProps } from '../interface';
 
+type ArrowIconProps = {
+  /** DIcon props used to render the "previous" arrow icon. */
+  iconArrowLeft?: ComponentProps<typeof DIcon>;
+  /** DIcon props used to render the "next" arrow icon. */
+  iconArrowRight?: ComponentProps<typeof DIcon>;
+};
+
 type Props =
 & SplideProps
-& PropsWithChildren<BaseProps>;
+& PropsWithChildren<BaseProps>
+& ArrowIconProps;
+
+const DEFAULT_ARROW_PATH = 'm15.5 0.932-4.3 4.38 14.5 14.6-14.5 14.5 4.3 4.4 14.6-14.6 4.4-4.3-4.4-4.4-14.6-14.6z';
+
+function DefaultArrowIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 40 40"
+      width={40}
+      height={40}
+      focusable="false"
+      aria-hidden="true"
+    >
+      <path d={DEFAULT_ARROW_PATH} />
+    </svg>
+  );
+}
 
 function DCarousel(
   {
@@ -23,15 +50,20 @@ function DCarousel(
     style,
     options,
     dataAttributes,
+    iconArrowLeft,
+    iconArrowRight,
     ...props
   }: Props,
   ref: ForwardedRef<Splide>,
 ) {
+  const hasCustomArrows = Boolean(iconArrowLeft || iconArrowRight);
+
   return (
     <Splide
       className={classNames('d-carousel', className)}
       style={style}
       ref={ref}
+      hasTrack={!hasCustomArrows}
       options={{
         ...options,
         classes: {
@@ -48,7 +80,27 @@ function DCarousel(
       {...dataAttributes}
       {...props}
     >
-      {children}
+      {hasCustomArrows ? (
+        <>
+          <SplideTrack>
+            {children}
+          </SplideTrack>
+          <div className="splide__arrows d-carousel-arrows">
+            <button
+              type="button"
+              className="splide__arrow splide__arrow--prev d-carousel-arrow d-carousel-arrow-prev"
+            >
+              {iconArrowLeft ? <DIcon {...iconArrowLeft} /> : <DefaultArrowIcon />}
+            </button>
+            <button
+              type="button"
+              className="splide__arrow splide__arrow--next d-carousel-arrow d-carousel-arrow-next"
+            >
+              {iconArrowRight ? <DIcon {...iconArrowRight} /> : <DefaultArrowIcon />}
+            </button>
+          </div>
+        </>
+      ) : children}
     </Splide>
   );
 }

--- a/src/components/DCarousel/DCarousel.tsx
+++ b/src/components/DCarousel/DCarousel.tsx
@@ -52,18 +52,19 @@ function DCarousel(
     dataAttributes,
     iconArrowLeft,
     iconArrowRight,
+    hasTrack: propsHasTrack,
     ...props
   }: Props,
   ref: ForwardedRef<Splide>,
 ) {
-  const hasCustomArrows = Boolean(iconArrowLeft || iconArrowRight);
+  // Explicit `options.arrows === false` always wins, even when icon props are set.
+  const hasCustomArrows = Boolean((iconArrowLeft || iconArrowRight) && options?.arrows !== false);
 
   return (
     <Splide
       className={classNames('d-carousel', className)}
       style={style}
       ref={ref}
-      hasTrack={!hasCustomArrows}
       options={{
         ...options,
         classes: {
@@ -79,6 +80,10 @@ function DCarousel(
       }}
       {...dataAttributes}
       {...props}
+      // Rendering our own arrows requires taking over the track wrapper, so this
+      // must be applied after `...props` to prevent a consumer-provided `hasTrack`
+      // from re-enabling Splide's automatic track when custom arrows are active.
+      hasTrack={hasCustomArrows ? false : propsHasTrack}
     >
       {hasCustomArrows ? (
         <>

--- a/src/style/components/_d-carousel.scss
+++ b/src/style/components/_d-carousel.scss
@@ -42,8 +42,22 @@
     height: $carousel-control-height;
     background: var(--#{$prefix}primary);
     padding: var(--#{$prefix}ref-spacer-1);
-    svg {
+
+    // Only invert the default arrow icon (a bare <svg> as a direct child).
+    // Custom icons rendered via `iconArrowLeft`/`iconArrowRight` use DIcon
+    // (wrapped in a .d-icon span) and are reset below, so they are untouched here.
+    > svg {
       filter: invert(1);
+    }
+
+    // Splide's default theme applies `fill` and, for the prev arrow, a
+    // `scaleX(-1)` flip to every descendant <svg>, assuming a single arrow
+    // path reused for both directions. Since `iconArrowLeft`/`iconArrowRight`
+    // are always a DIcon with its own icon/color, cancel both so the icon
+    // keeps its intended orientation and color.
+    .d-icon svg {
+      fill: none;
+      transform: none;
     }
   }
 

--- a/src/style/components/_d-carousel.scss
+++ b/src/style/components/_d-carousel.scss
@@ -52,9 +52,13 @@
 
     // Splide's default theme applies `fill` and, for the prev arrow, a
     // `scaleX(-1)` flip to every descendant <svg>, assuming a single arrow
-    // path reused for both directions. Since `iconArrowLeft`/`iconArrowRight`
-    // are always a DIcon with its own icon/color, cancel both so the icon
-    // keeps its intended orientation and color.
+    // path reused for both directions. `iconArrowLeft`/`iconArrowRight` are
+    // typed as DIcon props, so the only <svg> rendered here is a Lucide icon,
+    // which is always stroke-based with `fill="none"` (see lucide-react
+    // defaultAttributes). Resetting to `fill: none` restores that intended
+    // stroke-only look and lets DIcon's own `color` (applied via `currentColor`
+    // on stroke) keep controlling the icon color; `transform: none` cancels
+    // the flip so the icon keeps its intended orientation.
     .d-icon svg {
       fill: none;
       transform: none;

--- a/stories/components/DCarousel.stories.tsx
+++ b/stories/components/DCarousel.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import DCarousel from '../../src/components/DCarousel/DCarousel';
+import { DCarousel } from '../../src';
 import { PREFIX_BS } from '../../src/components/config';
 
 const config: Meta<typeof DCarousel> = {
@@ -44,6 +44,24 @@ To understand in more detail the aspects covered by this component, review the f
       control: 'object',
       table: { category: 'Appearance' },
     },
+    iconArrowLeft: {
+      control: false,
+      description: 'DIcon props used to render the "previous" arrow icon (e.g. `{ icon: "ArrowLeft", color: "light" }`).',
+      table: {
+        type: { summary: 'ComponentProps<typeof DIcon>' },
+        defaultValue: { summary: 'undefined' },
+        category: 'Icon',
+      },
+    },
+    iconArrowRight: {
+      control: false,
+      description: 'DIcon props used to render the "next" arrow icon (e.g. `{ icon: "ArrowRight", color: "light" }`).',
+      table: {
+        type: { summary: 'ComponentProps<typeof DIcon>' },
+        defaultValue: { summary: 'undefined' },
+        category: 'Icon',
+      },
+    },
   },
   tags: ['autodocs'],
 };
@@ -72,6 +90,39 @@ export const Default: Story = {
     </DCarousel>
   ),
   args: {
+    options: {
+      perPage: 1,
+      width: 532,
+      updateOnMove: true,
+      gap: '0.5rem',
+      padding: '1rem',
+    },
+  },
+};
+
+export const CustomArrows: Story = {
+  render: (args) => (
+    <DCarousel
+      {...args}
+    >
+      {[1, 2, 3, 4, 5].map((el) => (
+        <DCarousel.Slide key={el}>
+          <div className="d-flex flex-column bg-light border p-3 rounded text-center">
+            <h5>{`Slide ${el}`}</h5>
+            <p>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Unde, cumque?
+              Fugiat illum repellat nemo laboriosam voluptatum, temporibus eius facilis
+              expedita incidunt itaque odio non necessitatibus dolore molestias,
+              harum dicta a!
+            </p>
+          </div>
+        </DCarousel.Slide>
+      ))}
+    </DCarousel>
+  ),
+  args: {
+    iconArrowRight: { icon: 'CircleArrowRight', color: 'light' },
+    iconArrowLeft: { icon: 'CircleArrowLeft', color: 'light' },
     options: {
       perPage: 1,
       width: 532,


### PR DESCRIPTION
## Resumen

Agrega las props `iconArrowLeft` e `iconArrowRight` a `DCarousel`, permitiendo customizar completamente los íconos de las flechas prev/next en lugar de depender del SVG hardcodeado por defecto.

Closes #1106

## Cambios

- **`DCarousel.tsx`**: nuevas props `iconArrowLeft?: ComponentProps<typeof DIcon>` / `iconArrowRight?: ComponentProps<typeof DIcon>`. Al usarlas, el componente desactiva el `hasTrack` automático de `SplideTrack` y renderiza las flechas manualmente con las mismas clases que Splide espera (`splide__arrow--prev/next`), de forma que Splide sigue gestionando automáticamente `disabled`, `aria-label` (i18n) y la navegación por click.
- **`_d-carousel.scss`**: corrige un bug donde el tema por defecto de Splide aplica `fill` y, en la flecha "prev", `scaleX(-1)` a **cualquier** `<svg>` descendiente de `.splide__arrow`. Esto rotaba y forzaba el color de los íconos custom renderizados vía `DIcon`. Se resetean ambas propiedades únicamente dentro de `.d-icon svg`, dejando intacto el comportamiento del ícono default (que sí depende de ese flip para reusar un único path en ambos sentidos).
- **`DCarousel.spec.tsx`**: nuevos tests que verifican el render de íconos custom con color, y el fallback al ícono default cuando solo se especifica un lado.
- **`DCarousel.stories.tsx`**: nueva story `CustomArrows` y `argTypes` documentando las nuevas props en Storybook.

## Sin breaking changes

Si no se pasan las nuevas props, el render es idéntico al actual (snapshot existente sin cambios).

## Validación

- ✅ Suite completa: 73 test suites / tests pasan sin regresiones.
- ✅ `tsc --noEmit`, `eslint` y `stylelint` limpios.