### PR TITLE
docs(utils): add Storybook documentation and examples for public utils

### DIFF
--- a/src/utils/getQueryString.ts
+++ b/src/utils/getQueryString.ts
@@ -3,11 +3,10 @@ export default function getQueryString(
   config: {
     default?: string;
     useSearch?: boolean;
-  } = {
-    useSearch: true,
-  },
+  } = {},
 ): string | undefined {
-  const urlParams = new URLSearchParams(config.useSearch ? window.location.search : '');
+  const { useSearch = true, default: defaultValue } = config;
+  const urlParams = new URLSearchParams(useSearch ? window.location.search : '');
 
-  return urlParams.get(value) || config.default;
+  return urlParams.get(value) || defaultValue;
 }

--- a/src/utils/tests/getQueryString.spec.ts
+++ b/src/utils/tests/getQueryString.spec.ts
@@ -26,4 +26,8 @@ describe('getQueryString', () => {
     expect(getQueryString('foo', { useSearch: false })).toBeUndefined();
     expect(getQueryString('foo', { useSearch: false, default: 'x' })).toBe('x');
   });
+
+  it('should still read the real query string when only default is provided', () => {
+    expect(getQueryString('foo', { default: 'defaultValue' })).toBe('bar');
+  });
 });

--- a/stories/components/DCurrencyText.stories.tsx
+++ b/stories/components/DCurrencyText.stories.tsx
@@ -5,7 +5,7 @@ import DCurrencyText from '../../src/components/DCurrencyText/DCurrencyText';
 import { DContextProvider } from '../../src';
 
 const config: Meta<typeof DCurrencyText> = {
-  title: 'Design System/Utils/Currency Text',
+  title: 'Design System/Components/Currency Text',
   component: DCurrencyText,
   argTypes: {
     value: {

--- a/stories/examples/DTextBgVariants.stories.tsx
+++ b/stories/examples/DTextBgVariants.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
 const config: Meta = {
-  title: 'Design System/Utils/Text Background Variants',
+  title: 'Design System/Examples/Text Background Variants',
   parameters: {
     layout: 'centered',
     docs: {

--- a/stories/utils/configureI18n.mdx
+++ b/stories/utils/configureI18n.mdx
@@ -1,0 +1,52 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './configureI18nExamples';
+
+<Meta title="Design System/Utils/configureI18n" />
+
+# configureI18n
+Initializes `i18next` with `react-i18next`, given a set of translation resources.
+
+## Parameters
+
+- **resources** (`Resource` from `i18next`): The translation resources, keyed by language and namespace.
+- **config** (optional, `InitOptions` from `i18next`):
+  - **lng** (`string`, default `'en'`): The active language.
+  - **fallbackLng** (`string`, default `'en'`): The language to fall back to when a key is missing.
+  - Any other `i18next` `InitOptions` are also supported.
+
+## Returns
+
+- (`Promise<TFunction>`): A promise that resolves to the `i18next` translate function (`t`).
+
+## Example of use
+
+<Source
+  code={
+    `
+import { configureI18n } from '@dynamic-framework/ui-react';
+
+const resources = {
+  en: { translation: { hello: 'Hello', greet: 'Hi {name}!' } },
+  es: { translation: { hello: 'Hola', greet: '¡Hola {name}!' } },
+};
+
+const t = await configureI18n(resources, { lng: 'en' });
+t('hello'); // 'Hello'
+t('greet', { name: 'John' }); // 'Hi John!'
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+Switch the language to see `configureI18n` re-initialize `i18next` and translate the sample keys.
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/configureI18nExamples.tsx
+++ b/stories/utils/configureI18nExamples.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import type { TFunction } from 'i18next';
+import {
+  DButton,
+  DCard,
+  configureI18n,
+} from '../../src';
+
+const resources = {
+  en: { translation: { hello: 'Hello', greet: 'Hi {name}!' } },
+  es: { translation: { hello: 'Hola', greet: '¡Hola {name}!' } },
+};
+
+function ExampleOfUse() {
+  const [t, setT] = useState<TFunction>();
+  const [lng, setLng] = useState<'en' | 'es'>('en');
+
+  useEffect(() => {
+    let active = true;
+    configureI18n(resources, { lng })
+      .then((translate) => {
+        if (active) {
+          setT(() => translate);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [lng]);
+
+  return (
+    <DCard>
+      <DCard.Header>
+        configureI18n
+      </DCard.Header>
+      <DCard.Body>
+        <pre className="mb-0">
+          {t ? `${t('hello')} / ${t('greet', { name: 'John' })}` : 'Loading...'}
+        </pre>
+      </DCard.Body>
+      <DCard.Footer className="d-flex justify-content-end gap-3">
+        <DButton size="sm" onClick={() => setLng('en')} text="English" />
+        <DButton size="sm" onClick={() => setLng('es')} text="Español" />
+      </DCard.Footer>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/utils/formatCurrency.mdx
+++ b/stories/utils/formatCurrency.mdx
@@ -1,0 +1,45 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './formatCurrencyExamples';
+
+<Meta title="Design System/Utils/formatCurrency" />
+
+# formatCurrency
+Formats a number as a currency string using `currency.js`.
+
+## Parameters
+
+- **amount** (`number`): The numeric value to format.
+- **options** (`Options` from `currency.js`): Formatting options such as `symbol`, `precision`, `separator` and `decimal`.
+
+## Returns
+
+- (`string`): The formatted currency value.
+
+## Example of use
+
+<Source
+  code={
+    `
+import { formatCurrency } from '@dynamic-framework/ui-react';
+
+const values = [100, 234.12, -233].map((amount) => formatCurrency(amount, {
+  symbol: '$',
+  precision: 2,
+  separator: ',',
+  decimal: '.',
+}));
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/formatCurrencyExamples.tsx
+++ b/stories/utils/formatCurrencyExamples.tsx
@@ -1,0 +1,18 @@
+import { formatCurrency } from '../../src';
+
+export function ExampleRoot() {
+  const values = [100, 234.12, -233].map((amount) => formatCurrency(amount, {
+    symbol: '$',
+    precision: 2,
+    separator: ',',
+    decimal: '.',
+  }));
+
+  return (
+    <div className="p-3">
+      {values.map((value) => (
+        <pre key={value}>{value}</pre>
+      ))}
+    </div>
+  );
+}

--- a/stories/utils/getCssVariable.mdx
+++ b/stories/utils/getCssVariable.mdx
@@ -1,0 +1,39 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './getCssVariableExamples';
+
+<Meta title="Design System/Utils/getCssVariable" />
+
+# getCssVariable
+Reads the computed value of a CSS custom property defined on the document root (`:root`).
+
+## Parameters
+
+- **variable** (`string`): The name of the CSS variable, including the leading `--`.
+
+## Returns
+
+- (`string`): The trimmed computed value of the variable, or an empty string if it is not defined.
+
+## Example of use
+
+<Source
+  code={
+    `
+import { getCssVariable } from '@dynamic-framework/ui-react';
+
+const primaryColor = getCssVariable('--bs-primary');
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/getCssVariableExamples.tsx
+++ b/stories/utils/getCssVariableExamples.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import {
+  DButton,
+  DCard,
+  getCssVariable,
+} from '../../src';
+
+function ExampleOfUse() {
+  const [value, setValue] = useState('');
+
+  const handleRead = () => {
+    setValue(getCssVariable('--bs-primary'));
+  };
+
+  return (
+    <DCard>
+      <DCard.Header>
+        getCssVariable(&apos;--bs-primary&apos;)
+      </DCard.Header>
+      <DCard.Body className="d-flex align-items-center gap-3">
+        <div
+          style={{
+            width: '2rem',
+            height: '2rem',
+            backgroundColor: value || 'transparent',
+            border: '1px solid var(--bs-border-color)',
+          }}
+        />
+        <pre className="mb-0">{value || '(not read yet)'}</pre>
+      </DCard.Body>
+      <DCard.Footer className="d-flex justify-content-end">
+        <DButton size="sm" onClick={handleRead} text="Read --bs-primary" />
+      </DCard.Footer>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/utils/mediaQuery/checkMediaQuery.mdx
+++ b/stories/utils/mediaQuery/checkMediaQuery.mdx
@@ -1,0 +1,46 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './checkMediaQueryExamples';
+
+<Meta title="Design System/Utils/mediaQuery/checkMediaQuery" />
+
+# checkMediaQuery
+Synchronously checks whether a media query currently matches, using `window.matchMedia`.
+
+## Parameters
+
+- **query** (`string`): A valid CSS media query, e.g. `'(min-width: 768px)'`.
+
+## Returns
+
+- (`boolean`): `true` when the media query currently matches, `false` otherwise.
+
+> This is a one-off, point-in-time check — it does **not** react to viewport
+> changes by itself. To be notified when the match changes over time, combine
+> it with `subscribeToMediaQuery` (see that doc) or use the `useMediaQuery` hook.
+
+## Example of use
+
+<Source
+  code={
+    `
+import { checkMediaQuery } from '@dynamic-framework/ui-react';
+
+const matches = checkMediaQuery('(min-width: 768px)');
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+Resize the box below (it's an isolated viewport) and click "Check now" to read
+the match at that exact moment — notice it won't update on its own while you drag.
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/mediaQuery/checkMediaQueryExamples.tsx
+++ b/stories/utils/mediaQuery/checkMediaQueryExamples.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { DButton, DCard } from '../../../src';
+
+const QUERY = '(min-width: 768px)';
+
+function ExampleOfUse() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [width, setWidth] = useState(0);
+  const [matches, setMatches] = useState<boolean>();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    setWidth(container.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver(([entry]) => {
+      setWidth(entry.contentRect.width);
+    });
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, []);
+
+  // Reads the match state once, at the moment of the click, the same way
+  // `checkMediaQuery` does internally (`window.matchMedia(query).matches`).
+  // It does not react to width changes on its own: resize the box and press
+  // the button again to see the updated (one-off) result.
+  const handleCheck = () => {
+    const win = iframeRef.current?.contentWindow;
+    setMatches(win ? win.matchMedia(QUERY).matches : undefined);
+  };
+
+  return (
+    <DCard>
+      <DCard.Header>
+        {QUERY}
+      </DCard.Header>
+      <DCard.Body>
+        <p className="mb-2">
+          Drag the bottom-right corner to resize the box (an isolated viewport),
+          then click &quot;Check now&quot; to read the match at that instant.
+        </p>
+        <div
+          ref={containerRef}
+          style={{
+            position: 'relative',
+            resize: 'horizontal',
+            overflow: 'hidden',
+            border: '1px solid var(--bs-border-color)',
+            width: 900,
+            maxWidth: '100%',
+            minWidth: 320,
+            height: 48,
+          }}
+        >
+          <iframe
+            ref={iframeRef}
+            title="checkMediaQuery resizable preview"
+            style={{ width: '100%', height: '100%', border: 'none' }}
+          />
+          <span
+            className="badge text-bg-dark"
+            style={{ position: 'absolute', top: 4, left: 4 }}
+          >
+            {`Width: ${Math.round(width)}px`}
+          </span>
+        </div>
+        <div className="d-flex align-items-center gap-3 mt-3">
+          <DButton size="sm" onClick={handleCheck} text="Check now" />
+          <pre className="mb-0">
+            {matches === undefined ? 'Matches: (not checked yet)' : `Matches: ${matches}`}
+          </pre>
+        </div>
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/utils/mediaQuery/checkMediaQueryExamples.tsx
+++ b/stories/utils/mediaQuery/checkMediaQueryExamples.tsx
@@ -41,7 +41,7 @@ function ExampleOfUse() {
       </DCard.Header>
       <DCard.Body>
         <p className="mb-2">
-          Drag the bottom-right corner to resize the box (an isolated viewport),
+          Drag the right edge to resize the box (an isolated viewport),
           then click &quot;Check now&quot; to read the match at that instant.
         </p>
         <div

--- a/stories/utils/mediaQuery/subscribeToMediaQuery.mdx
+++ b/stories/utils/mediaQuery/subscribeToMediaQuery.mdx
@@ -51,7 +51,7 @@ function ExampleOfUse() {
 
 ## Example Render
 
-Drag the bottom-right corner of the box below to resize it and watch
+Drag the right edge of the box below to resize it and watch
 &quot;Matches&quot; update automatically, without any manual action.
 
 <Unstyled>

--- a/stories/utils/mediaQuery/subscribeToMediaQuery.mdx
+++ b/stories/utils/mediaQuery/subscribeToMediaQuery.mdx
@@ -1,0 +1,59 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './subscribeToMediaQueryExamples';
+
+<Meta title="Design System/Utils/mediaQuery/subscribeToMediaQuery" />
+
+# subscribeToMediaQuery
+Subscribes to changes of a media query, invoking a callback whenever its match state changes.
+
+## Parameters
+
+- **query** (`string`): A valid CSS media query, e.g. `'(min-width: 768px)'`.
+- **callback** (`() => void`): Invoked every time the media query's match state changes.
+
+## Returns
+
+- (`() => void`): An unsubscribe function. Call it (e.g. in a `useEffect` cleanup) to stop listening.
+
+> This is the reactive counterpart of `checkMediaQuery`: use `checkMediaQuery` to
+> read the current value and `subscribeToMediaQuery` to be notified of further
+> changes. This is exactly how the `useMediaQuery` hook is built internally.
+
+## Example of use
+
+<Source
+  code={
+    `
+import { subscribeToMediaQuery, checkMediaQuery } from '@dynamic-framework/ui-react';
+import { useEffect, useState } from 'react';
+
+const QUERY = '(min-width: 768px)';
+
+function ExampleOfUse() {
+  const [matches, setMatches] = useState(() => checkMediaQuery(QUERY));
+
+  useEffect(
+    () => subscribeToMediaQuery(QUERY, () => setMatches(checkMediaQuery(QUERY))),
+    [],
+  );
+
+  return <p>{\`Matches: \${matches}\`}</p>;
+}
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+Drag the bottom-right corner of the box below to resize it and watch
+&quot;Matches&quot; update automatically, without any manual action.
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/mediaQuery/subscribeToMediaQueryExamples.tsx
+++ b/stories/utils/mediaQuery/subscribeToMediaQueryExamples.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from 'react';
+import { DCard } from '../../../src';
+
+const QUERY = '(min-width: 768px)';
+
+function ExampleOfUse() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [width, setWidth] = useState(0);
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    setWidth(container.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver(([entry]) => {
+      setWidth(entry.contentRect.width);
+    });
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) {
+      return undefined;
+    }
+
+    // Mirrors what `subscribeToMediaQuery` does internally: it creates a
+    // `MediaQueryList` and subscribes to its `change` event, keeping `matches`
+    // in sync automatically as the viewport (here, the resizable box) changes.
+    let mediaQueryList: MediaQueryList | undefined;
+    const handleChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+    const attach = () => {
+      const win = iframe.contentWindow;
+      if (!win) {
+        return;
+      }
+      mediaQueryList = win.matchMedia(QUERY);
+      setMatches(mediaQueryList.matches);
+      mediaQueryList.addEventListener('change', handleChange);
+    };
+
+    iframe.addEventListener('load', attach);
+    attach();
+
+    return () => {
+      iframe.removeEventListener('load', attach);
+      mediaQueryList?.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return (
+    <DCard>
+      <DCard.Header>
+        {QUERY}
+      </DCard.Header>
+      <DCard.Body>
+        <p className="mb-2">
+          Drag the bottom-right corner of the box below (an isolated viewport)
+          to resize it and see &quot;Matches&quot; update automatically, without
+          clicking anything.
+        </p>
+        <div
+          ref={containerRef}
+          style={{
+            position: 'relative',
+            resize: 'horizontal',
+            overflow: 'hidden',
+            border: '1px solid var(--bs-border-color)',
+            width: 900,
+            maxWidth: '100%',
+            minWidth: 320,
+            height: 48,
+          }}
+        >
+          <iframe
+            ref={iframeRef}
+            title="subscribeToMediaQuery resizable preview"
+            style={{ width: '100%', height: '100%', border: 'none' }}
+          />
+          <span
+            className="badge text-bg-dark"
+            style={{ position: 'absolute', top: 4, left: 4 }}
+          >
+            {`Width: ${Math.round(width)}px`}
+          </span>
+        </div>
+        <pre className="mt-3 mb-0">{`Matches: ${matches}`}</pre>
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/utils/mediaQuery/subscribeToMediaQueryExamples.tsx
+++ b/stories/utils/mediaQuery/subscribeToMediaQueryExamples.tsx
@@ -39,7 +39,7 @@ function ExampleOfUse() {
 
     const attach = () => {
       const win = iframe.contentWindow;
-      if (!win) {
+      if (!win || mediaQueryList) {
         return;
       }
       mediaQueryList = win.matchMedia(QUERY);
@@ -47,8 +47,8 @@ function ExampleOfUse() {
       mediaQueryList.addEventListener('change', handleChange);
     };
 
-    iframe.addEventListener('load', attach);
     attach();
+    iframe.addEventListener('load', attach);
 
     return () => {
       iframe.removeEventListener('load', attach);

--- a/stories/utils/mediaQuery/subscribeToMediaQueryExamples.tsx
+++ b/stories/utils/mediaQuery/subscribeToMediaQueryExamples.tsx
@@ -63,7 +63,7 @@ function ExampleOfUse() {
       </DCard.Header>
       <DCard.Body>
         <p className="mb-2">
-          Drag the bottom-right corner of the box below (an isolated viewport)
+          Drag the right edge of the box below (an isolated viewport)
           to resize it and see &quot;Matches&quot; update automatically, without
           clicking anything.
         </p>

--- a/stories/utils/queryString/changeQueryString.mdx
+++ b/stories/utils/queryString/changeQueryString.mdx
@@ -12,7 +12,7 @@ Adds, updates or removes parameters in the current URL query string.
 
 ## Parameters
 
-- **values** (`Record<string, string | number | null>`): Key/value pairs to set. A `null`/falsy value removes the key.
+- **values** (`Record<string, string | number | null>`): Key/value pairs to set. A falsy value (`null`, `undefined`, `''`, or **`0`**) removes the key instead of setting it — this applies even though `0` is a valid `number`, since the implementation uses a truthiness check. If you need to store a literal `0`, pass it as the string `'0'`.
 - **config** (optional):
   - **useSearch** (`boolean`, default `true`): Whether to start from the current `window.location.search`.
   - **pushState** (`boolean`, default `false`): Whether to update the browser URL via `window.history.pushState`.

--- a/stories/utils/queryString/changeQueryString.mdx
+++ b/stories/utils/queryString/changeQueryString.mdx
@@ -1,0 +1,47 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './changeQueryStringExamples';
+
+<Meta title="Design System/Utils/queryString/changeQueryString" />
+
+# changeQueryString
+Adds, updates or removes parameters in the current URL query string.
+
+## Parameters
+
+- **values** (`Record<string, string | number | null>`): Key/value pairs to set. A `null`/falsy value removes the key.
+- **config** (optional):
+  - **useSearch** (`boolean`, default `true`): Whether to start from the current `window.location.search`.
+  - **pushState** (`boolean`, default `false`): Whether to update the browser URL via `window.history.pushState`.
+
+## Returns
+
+- (`string`): The resulting query string (without the leading `?`).
+
+## Example of use
+
+<Source
+  code={
+    `
+import { changeQueryString } from '@dynamic-framework/ui-react';
+
+const result = changeQueryString(
+  { section: 'utils', page: 2 },
+  { pushState: true },
+);
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+Click the buttons to set or clear query string parameters and see the resulting `window.location.search`.
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/queryString/changeQueryStringExamples.tsx
+++ b/stories/utils/queryString/changeQueryStringExamples.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import {
+  DButton,
+  DCard,
+  changeQueryString,
+} from '../../../src';
+
+function ExampleOfUse() {
+  const [search, setSearch] = useState(() => window.location.search);
+
+  const handleSet = () => {
+    const result = changeQueryString(
+      { section: 'utils', page: 2 },
+      { pushState: true },
+    );
+    setSearch(`?${result}`);
+  };
+
+  const handleClear = () => {
+    const result = changeQueryString(
+      { section: null, page: null },
+      { pushState: true },
+    );
+    setSearch(result ? `?${result}` : '');
+  };
+
+  return (
+    <DCard>
+      <DCard.Header>
+        window.location.search
+      </DCard.Header>
+      <DCard.Body>
+        <pre>{search || '(empty)'}</pre>
+      </DCard.Body>
+      <DCard.Footer className="d-flex justify-content-end gap-3">
+        <DButton size="sm" onClick={handleSet} text="Set section & page" />
+        <DButton size="sm" onClick={handleClear} text="Clear" />
+      </DCard.Footer>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/utils/queryString/getQueryString.mdx
+++ b/stories/utils/queryString/getQueryString.mdx
@@ -17,7 +17,7 @@ Reads a value from the current URL query string.
   - **default** (`string`): Value returned when the parameter is not present.
   - **useSearch** (`boolean`, default `true`): Whether to read from `window.location.search`.
 
-> ⚠️ **Note:** `useSearch` only defaults to `true` when `config` itself is omitted entirely. If you pass a `config` object without `useSearch`, it will be `undefined` (falsy) and the function will read from an empty string instead of the URL. Always pass `useSearch: true` explicitly when providing other options.
+> ℹ️ **Note:** `useSearch` defaults to `true` even when `config` is only partially provided (e.g. `{ default: 'x' }` without `useSearch`), so the current query string is read by default unless you explicitly pass `useSearch: false`.
 
 ## Returns
 
@@ -30,7 +30,7 @@ Reads a value from the current URL query string.
     `
 import { getQueryString } from '@dynamic-framework/ui-react';
 
-const demo = getQueryString('demo', { default: 'no value yet', useSearch: true });
+const demo = getQueryString('demo', { default: 'no value yet' });
 `
   }
   language="tsx"

--- a/stories/utils/queryString/getQueryString.mdx
+++ b/stories/utils/queryString/getQueryString.mdx
@@ -1,0 +1,46 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './getQueryStringExamples';
+
+<Meta title="Design System/Utils/queryString/getQueryString" />
+
+# getQueryString
+Reads a value from the current URL query string.
+
+## Parameters
+
+- **value** (`string`): The name of the query string parameter to read.
+- **config** (optional):
+  - **default** (`string`): Value returned when the parameter is not present.
+  - **useSearch** (`boolean`, default `true`): Whether to read from `window.location.search`.
+
+> ⚠️ **Note:** `useSearch` only defaults to `true` when `config` itself is omitted entirely. If you pass a `config` object without `useSearch`, it will be `undefined` (falsy) and the function will read from an empty string instead of the URL. Always pass `useSearch: true` explicitly when providing other options.
+
+## Returns
+
+- (`string | undefined`): The parameter value, the provided default, or `undefined`.
+
+## Example of use
+
+<Source
+  code={
+    `
+import { getQueryString } from '@dynamic-framework/ui-react';
+
+const demo = getQueryString('demo', { default: 'no value yet', useSearch: true });
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+Use the buttons below to update the `demo` query string parameter (via `changeQueryString`) and see how `getQueryString` reads it back.
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/queryString/getQueryStringExamples.tsx
+++ b/stories/utils/queryString/getQueryStringExamples.tsx
@@ -6,7 +6,7 @@ import {
   getQueryString,
 } from '../../../src';
 
-const readDemoValue = () => getQueryString('demo', { default: 'no value yet', useSearch: true });
+const readDemoValue = () => getQueryString('demo', { default: 'no value yet' });
 
 function ExampleOfUse() {
   const [value, setValue] = useState(readDemoValue);

--- a/stories/utils/queryString/getQueryStringExamples.tsx
+++ b/stories/utils/queryString/getQueryStringExamples.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import {
+  DButton,
+  DCard,
+  changeQueryString,
+  getQueryString,
+} from '../../../src';
+
+const readDemoValue = () => getQueryString('demo', { default: 'no value yet', useSearch: true });
+
+function ExampleOfUse() {
+  const [value, setValue] = useState(readDemoValue);
+
+  const handleSet = () => {
+    changeQueryString({ demo: 'hello-world' }, { pushState: true });
+    setValue(readDemoValue());
+  };
+
+  const handleClear = () => {
+    changeQueryString({ demo: null }, { pushState: true });
+    setValue(readDemoValue());
+  };
+
+  return (
+    <DCard>
+      <DCard.Header>
+        getQueryString(&apos;demo&apos;)
+      </DCard.Header>
+      <DCard.Body>
+        <pre>{value}</pre>
+      </DCard.Body>
+      <DCard.Footer className="d-flex justify-content-end gap-3">
+        <DButton size="sm" onClick={handleSet} text="Set ?demo=hello-world" />
+        <DButton size="sm" onClick={handleClear} text="Clear" />
+      </DCard.Footer>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/utils/validatePhoneNumber.mdx
+++ b/stories/utils/validatePhoneNumber.mdx
@@ -1,0 +1,39 @@
+import {
+  Meta,
+  Unstyled,
+  Source,
+} from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './validatePhoneNumberExamples';
+
+<Meta title="Design System/Utils/validatePhoneNumber" />
+
+# validatePhoneNumber
+Validates whether a string is a valid phone number, using `google-libphonenumber`.
+
+## Parameters
+
+- **phone** (`string`): The phone number to validate. It should include the country code (e.g. `+1 650-253-0000`).
+
+## Returns
+
+- (`boolean`): `true` when the number is valid, `false` otherwise (including when the number cannot be parsed).
+
+## Example of use
+
+<Source
+  code={
+    `
+import { validatePhoneNumber } from '@dynamic-framework/ui-react';
+
+const isValid = validatePhoneNumber('+1 650-253-0000');
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/utils/validatePhoneNumberExamples.tsx
+++ b/stories/utils/validatePhoneNumberExamples.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import {
+  DInput,
+  DCard,
+  validatePhoneNumber,
+} from '../../src';
+
+function ExampleOfUse() {
+  const [phone, setPhone] = useState('+1 650-253-0000');
+
+  const isValid = validatePhoneNumber(phone);
+
+  return (
+    <DCard>
+      <DCard.Header>
+        validatePhoneNumber
+      </DCard.Header>
+      <DCard.Body>
+        <DInput
+          label="Phone number"
+          value={phone}
+          onChange={setPhone}
+          invalid={!isValid}
+        />
+        <p className={`mt-3 mb-0 ${isValid ? 'text-success' : 'text-danger'}`}>
+          {isValid ? 'Valid phone number' : 'Invalid phone number'}
+        </p>
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}


### PR DESCRIPTION
## Resumen

Cierra #1130 — varias utils públicas que exporta el framework no tenían documentación ni ejemplos de uso en Storybook.

Se agrega un `.mdx` + ejemplo funcional por cada util pública bajo `stories/utils/`, siguiendo el mismo patrón ya usado para los hooks (`stories/hooks/*`): descripción, parámetros/retorno, ejemplo de código y un ejemplo interactivo en vivo.

### Documentación agregada

- `formatCurrency`
- `configureI18n`
- `getCssVariable`
- `validatePhoneNumber`
- `queryString/getQueryString` y `queryString/changeQueryString` (agrupados, mismo concepto)
- `mediaQuery/checkMediaQuery` y `mediaQuery/subscribeToMediaQuery` (agrupados, mismo concepto)

### Stories mal clasificadas corregidas

`Design System/Utils/*` tenía dos entradas que en realidad no eran utils JS:

- `DCurrencyText` → movida a `Design System/Components/Currency Text` (es un componente real)
- `DTextBgVariants` → movida a `Design System/Examples/Text Background Variants` y reubicada en `stories/examples/`, igual que `Dark Utilities` / `Hover Utilities` (documenta clases CSS `text-bg-*` de Bootstrap, no una util JS)

### Bug corregido

Al construir el ejemplo interactivo de `getQueryString`, se encontró que pasar un objeto `config` con solo `default` (ej. `getQueryString('demo', { default: 'x' })`) ignoraba silenciosamente el query string real. Los parámetros por defecto de JS no se combinan con objetos parcialmente provistos, así que `config.useSearch` terminaba en `undefined`/falsy y la función siempre leía de un string vacío en vez de `window.location.search`.

Se corrigió desestructurando `config` con un default individual para `useSearch`, y se agregó un test de regresión.

## Pruebas

- `npx jest src/utils` → 43/43 exitosos
- `npx storybook build` → compila correctamente, todas las stories nuevas/movidas verificadas en el índice generado
- `npx eslint` en todos los archivos modificados → sin errores
