### PR TITLE
refactor(components): replace Bootstrap utility classes with semantic tokenized classes

### DIFF
--- a/src/components/DBoxFile/DBoxFile.tsx
+++ b/src/components/DBoxFile/DBoxFile.tsx
@@ -104,7 +104,7 @@ export default function DBoxFile(
             {typeof children === 'function'
               ? children(openFileDialog)
               : children || (
-                <p className="text-center m-0">
+                <p className="d-box-file-empty-text">
                   Drag and drop some files here, or click to select files
                 </p>
               )}

--- a/src/components/DConfirmModal/DConfirmModalUI.tsx
+++ b/src/components/DConfirmModal/DConfirmModalUI.tsx
@@ -71,8 +71,8 @@ export default function DConfirmModalUI({ entry }: Props) {
         <h5 className="fw-bold">{title}</h5>
       </DModal.Header>
 
-      <DModal.Body className="py-3 px-5">
-        <p className="mb-4">{message}</p>
+      <DModal.Body className="d-confirm-modal-body">
+        <p className="d-confirm-modal-message">{message}</p>
 
         {critical && (
           <DInput
@@ -81,7 +81,7 @@ export default function DConfirmModalUI({ entry }: Props) {
             placeholder={critical.inputPlaceholder}
             value={confirmationCode}
             onChange={(value) => setConfirmationCode(value)}
-            className="mb-4"
+            className="d-confirm-modal-field"
             autoFocus
           />
         )}

--- a/src/components/DDataStateWrapper/components/EmptyState.tsx
+++ b/src/components/DDataStateWrapper/components/EmptyState.tsx
@@ -15,13 +15,13 @@ export function EmptyState({
   onAction,
 }: EmptyStateProps) {
   return (
-    <div className="d-flex flex-column align-items-center justify-content-center p-5 text-center">
+    <div className="d-empty-state">
       <DIcon
         icon={icon}
         size="3rem"
-        className="text-secondary mb-3"
+        className="d-empty-state-icon"
       />
-      <p className="text-secondary mb-3">{message ?? 'No data available.'}</p>
+      <p className="d-empty-state-message">{message ?? 'No data available.'}</p>
       {actionText && onAction && (
         <DButton
           onClick={onAction}

--- a/src/components/DDataStateWrapper/components/ErrorState.tsx
+++ b/src/components/DDataStateWrapper/components/ErrorState.tsx
@@ -15,9 +15,9 @@ export function ErrorState({
   color = 'danger',
 }: ErrorStateProps) {
   return (
-    <DAlert color={color} className="d-flex align-items-center gap-3">
-      <div className="flex-grow-1">
-        <p className="mb-0">{message ?? 'An unexpected error occurred.'}</p>
+    <DAlert color={color} className="d-error-state">
+      <div className="d-error-state-content">
+        <p className="d-error-state-message">{message ?? 'An unexpected error occurred.'}</p>
       </div>
       {onRetry && (
         <DButton

--- a/src/components/DDataStateWrapper/components/LoadingState.tsx
+++ b/src/components/DDataStateWrapper/components/LoadingState.tsx
@@ -5,7 +5,7 @@ type LoadingStateProps = {
 
 export function LoadingState({ ariaLabel = 'Loading...', className }: LoadingStateProps) {
   return (
-    <div className={`d-flex align-items-center justify-content-center p-4 ${className || ''}`.trim()} aria-busy="true" aria-live="polite">
+    <div className={`d-loading-state ${className || ''}`.trim()} aria-busy="true" aria-live="polite">
       <span className="spinner-border" role="status" aria-label={ariaLabel} />
     </div>
   );

--- a/src/components/DDatePicker/components/DDatePickerHeaderSelector.tsx
+++ b/src/components/DDatePicker/components/DDatePickerHeaderSelector.tsx
@@ -191,7 +191,7 @@ export default function DDatePickerHeaderSelector(
           className="header-button"
           style={{ visibility: customHeaderCount === 0 ? 'visible' : 'hidden' }}
         />
-        <div className="d-flex justify-content-center flex-grow-1">
+        <div className="react-datepicker__header-year-selector">
           {showHeaderSelectors ? (
             <DSelect
               options={years}
@@ -231,7 +231,7 @@ export default function DDatePickerHeaderSelector(
             className="custom-year-selector"
           />
         )}
-        <h4 className="mb-0 fw-normal">
+        <h4 className="datepicker-top-header-title">
           {format(monthDate, formatHeaderDate, { locale })}
         </h4>
       </div>

--- a/src/components/DDropdown/DDropdown.tsx
+++ b/src/components/DDropdown/DDropdown.tsx
@@ -41,7 +41,7 @@ type Props = {
 };
 
 const getItemClass = (action: DropdownAction) => classNames({
-  'dropdown-item d-dropdown-item-content': true,
+  'dropdown-item d-flex align-items-center': true,
   [`dropdown-item-${action.color}`]: !!action.color,
   disabled: action.disabled,
 });
@@ -249,7 +249,7 @@ export default function DDropdown(
     <ul
       ref={menuRef}
       role="menu"
-      className={classNames('dropdown-menu', { show: open }, classNameMenu)}
+      className={classNames('dropdown-menu p-2', { show: open }, classNameMenu)}
       style={portalMenuStyle ?? inlineMenuStyle}
     >
       {actions.map((action, index) => {

--- a/src/components/DDropdown/DDropdown.tsx
+++ b/src/components/DDropdown/DDropdown.tsx
@@ -41,7 +41,7 @@ type Props = {
 };
 
 const getItemClass = (action: DropdownAction) => classNames({
-  'dropdown-item d-flex align-items-center': true,
+  'dropdown-item d-dropdown-item-content': true,
   [`dropdown-item-${action.color}`]: !!action.color,
   disabled: action.disabled,
 });
@@ -249,7 +249,7 @@ export default function DDropdown(
     <ul
       ref={menuRef}
       role="menu"
-      className={classNames('dropdown-menu p-2', { show: open }, classNameMenu)}
+      className={classNames('dropdown-menu', { show: open }, classNameMenu)}
       style={portalMenuStyle ?? inlineMenuStyle}
     >
       {actions.map((action, index) => {

--- a/src/components/DErrorBoundary/components/DefaultErrorBoundary.tsx
+++ b/src/components/DErrorBoundary/components/DefaultErrorBoundary.tsx
@@ -12,7 +12,7 @@ export default function DefaultErrorBoundary({ resetErrorBoundary }: Props) {
       color="danger"
       showClose={false}
     >
-      <div className="d-flex align-items-center gap-2">
+      <div className="d-error-boundary-content">
         <span>An unexpected error occurred.</span>
         <DButton
           color="secondary"

--- a/src/components/DModal/components/DModalHeader.tsx
+++ b/src/components/DModal/components/DModalHeader.tsx
@@ -47,7 +47,7 @@ export default function DModalHeader(
         {showCloseButton && (
           <button
             type="button"
-            className="d-close align-self-center"
+            className="d-close"
             aria-label="Close"
             onClick={onClose}
           >

--- a/src/components/DOffcanvas/components/DOffcanvasHeader.tsx
+++ b/src/components/DOffcanvas/components/DOffcanvasHeader.tsx
@@ -48,7 +48,7 @@ export default function DOffcanvasHeader(
         {showCloseButton && (
           <button
             type="button"
-            className="d-close align-self-center"
+            className="d-close"
             aria-label="Close"
             onClick={onClose}
           >

--- a/src/components/DOtp/DOtp.tsx
+++ b/src/components/DOtp/DOtp.tsx
@@ -75,8 +75,8 @@ export default function DOtp(
   return (
     <div className={className}>
       <p>{texts.title}</p>
-      <div className="d-flex flex-column gap-6 pb-4 px-3">
-        <div className="d-flex flex-column gap-6">
+      <div className="d-otp d-otp-content">
+        <div className="d-otp-fields">
           <DInputPin
             className="modal-otp-pin"
             characters={otpSize}
@@ -89,8 +89,8 @@ export default function DOtp(
             resendText={texts.resend}
           />
         </div>
-        <hr className="m-0" />
-        <div className="d-flex flex-column flex-lg-row gap-4 align-items-center">
+        <hr className="d-otp-divider" />
+        <div className="d-otp-footer">
           <DButton
             text={texts.submit}
             onClick={() => {
@@ -101,7 +101,7 @@ export default function DOtp(
             }}
             loading={isLoading}
           />
-          <p className="small ms-lg-auto mb-0">
+          <p className="d-otp-contact">
             {texts.contact}
           </p>
         </div>

--- a/src/components/DOtp/components/OtpCountdown.tsx
+++ b/src/components/DOtp/components/OtpCountdown.tsx
@@ -23,8 +23,8 @@ export default function OtpCountdown(
   const { secondsLeft, restartCountdown } = useCountdown(seconds);
 
   return (
-    <div className="d-flex gap-2 align-items-center">
-      <p className="mb-0 flex-1">
+    <div className="d-otp-countdown">
+      <p className="d-otp-countdown-text">
         {message ? message(secondsLeft) : defaultMessage(secondsLeft)}
       </p>
       <DButton

--- a/src/components/DPasswordStrengthMeter/PasswordCheckItem.tsx
+++ b/src/components/DPasswordStrengthMeter/PasswordCheckItem.tsx
@@ -1,5 +1,3 @@
-import classNames from 'classnames';
-
 import DIcon from '../DIcon';
 
 type Props = {
@@ -18,16 +16,13 @@ export default function PasswordCheckItem(
   const isValid = regex.test(password);
 
   return (
-    <li className="d-flex gap-2 align-items-start small text-gray-600">
+    <li className={`d-password-check-item${isValid ? ' is-valid' : ''}`}>
       <DIcon
-        className={classNames(
-          'flex-shrink-0',
-          isValid ? 'text-success' : 'text-gray-300',
-        )}
+        className="d-password-check-item-icon"
         icon={isValid ? 'CircleCheck' : 'Circle'}
         size="16px"
       />
-      <span className={classNames({ 'text-success': isValid })}>
+      <span>
         {text}
       </span>
     </li>

--- a/src/components/DPasswordStrengthMeter/PasswordCheckList.tsx
+++ b/src/components/DPasswordStrengthMeter/PasswordCheckList.tsx
@@ -55,9 +55,9 @@ export default function PasswordChecksList({
   const total = passwordChecks.length;
 
   return (
-    <div className="mt-2">
+    <div className="d-password-strength-meter">
       <PasswordStrengthBar strength={passed} total={total} />
-      <ul className="list-unstyled m-0 d-flex flex-column gap-2">
+      <ul className="d-password-check-list">
         {passwordChecks.map(({ key, regex, text }) => (
           <PasswordCheckItem
             key={key}

--- a/src/components/DPasswordStrengthMeter/PasswordStrength.tsx
+++ b/src/components/DPasswordStrengthMeter/PasswordStrength.tsx
@@ -3,29 +3,25 @@ type Props = {
   total: number;
 };
 
-const getColorClass = (strength: number, total: number): string => {
+const getStrengthModifier = (strength: number, total: number): string => {
   const percentage = total > 0 ? strength / total : 0;
 
-  if (percentage === 0) return 'bg-gray-200';
-  if (percentage <= 0.25) return 'bg-danger';
-  if (percentage <= 0.5) return 'bg-warning';
-  if (percentage <= 0.75) return 'bg-info';
-  return 'bg-success';
+  if (percentage === 0) return 'is-empty';
+  if (percentage <= 0.25) return 'is-weak';
+  if (percentage <= 0.5) return 'is-fair';
+  if (percentage <= 0.75) return 'is-good';
+  return 'is-strong';
 };
 
 export default function PasswordStrengthBar({ strength, total }: Props) {
   const percentage = total > 0 ? (strength / total) * 100 : 0;
 
   return (
-    <div
-      className="w-100 rounded-3 overflow-hidden bg-gray-100 mb-2"
-      style={{ height: '8px' }}
-    >
+    <div className="d-password-strength-bar">
       <div
-        className={`h-100 ${getColorClass(strength, total)}`}
+        className={`d-password-strength-bar-fill ${getStrengthModifier(strength, total)}`}
         style={{
           width: `${percentage}%`,
-          transition: 'width 0.3s ease-in-out',
         }}
       />
     </div>

--- a/src/components/DPopover/DPopover.spec.tsx
+++ b/src/components/DPopover/DPopover.spec.tsx
@@ -46,7 +46,7 @@ describe('<DPopover />', () => {
       );
 
       const popoverContent = screen.getByText('Content');
-      expect(popoverContent).toHaveClass('d-popover-content', 'w-100');
+      expect(popoverContent).toHaveClass('d-popover-content', 'd-popover-content-fill');
     });
   });
 

--- a/src/components/DPopover/DPopover.tsx
+++ b/src/components/DPopover/DPopover.tsx
@@ -114,7 +114,7 @@ export default function DPopover(
             className={classNames(
               'd-popover-content',
               {
-                'w-100': adjustContentToRender,
+                'd-popover-content-fill': adjustContentToRender,
               },
             )}
             ref={refs.setFloating}

--- a/src/components/DStepper/DStepper.tsx
+++ b/src/components/DStepper/DStepper.tsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames';
+
 import DStepperDesktop from '../DStepperDesktop';
 import DStepperMobile from '../DStepperMobile';
 
@@ -43,13 +45,13 @@ export default function DStepper(
       style={style}
       {...dataAttributes}
     >
-      <div className={`d-block d-${breakpoint}-none`}>
+      <div className={classNames('d-stepper-mobile', `d-block d-${breakpoint}-none`)}>
         <DStepperMobile
           options={options}
           currentStep={currentStep}
         />
       </div>
-      <div className={`d-none d-${breakpoint}-block`}>
+      <div className={classNames('d-stepper-desktop', `d-none d-${breakpoint}-block`)}>
         <DStepperDesktop
           options={options}
           currentStep={currentStep}

--- a/src/components/DTabs/DTabs.spec.tsx
+++ b/src/components/DTabs/DTabs.spec.tsx
@@ -155,7 +155,7 @@ describe('<DTabs />', () => {
     );
 
     const nav = container.querySelector('ul[role="tablist"]');
-    expect(nav).toHaveClass('flex-column', 'align-items-center');
+    expect(nav).toHaveClass('d-tabs-nav-vertical');
     expect(nav).toHaveClass('nav-pills');
   });
 
@@ -218,7 +218,7 @@ describe('<DTabs />', () => {
     );
 
     const nav = container.querySelector('ul[role="tablist"]');
-    expect(nav).toHaveClass('flex-column');
+    expect(nav).toHaveClass('d-tabs-nav-vertical');
   });
 
   it('reacts to changes in defaultSelected prop', () => {

--- a/src/components/DTabs/DTabs.tsx
+++ b/src/components/DTabs/DTabs.tsx
@@ -66,7 +66,7 @@ function DTabs(
   const generateClasses = useMemo(
     () => ({
       nav: true,
-      'flex-column align-items-center': vertical && variant !== 'tabs',
+      'd-tabs-nav-vertical': vertical && variant !== 'tabs',
       [`nav-${variant}`]: true,
       ...className && { [className]: true },
     }),
@@ -152,8 +152,8 @@ function DTabs(
     <TabContext.Provider value={value}>
       <div
         className={classNames({
-          'd-flex w-100': true,
-          'flex-column': !vertical || variant === 'tabs',
+          'd-tabs': true,
+          'd-tabs-column': !vertical || variant === 'tabs',
         })}
         style={style}
         {...dataAttributes}
@@ -195,7 +195,7 @@ function DTabs(
             );
           })}
         </ul>
-        <div className="tab-content w-100">
+        <div className="d-tabs-content tab-content">
           {children}
         </div>
       </div>

--- a/src/components/DToastContainer/useDToast.tsx
+++ b/src/components/DToastContainer/useDToast.tsx
@@ -111,7 +111,7 @@ export default function useDToast() {
               </p>
               <button
                 type="button"
-                className="d-close align-self-center"
+                className="d-close"
                 aria-label="Close"
                 onClick={() => reactHotToast.dismiss(id)}
               >
@@ -138,7 +138,7 @@ export default function useDToast() {
             )}
             <button
               type="button"
-              className="d-close align-self-center"
+              className="d-close"
               aria-label="Close"
               onClick={() => reactHotToast.dismiss(id)}
             >

--- a/src/components/DVoucher/DVoucher.tsx
+++ b/src/components/DVoucher/DVoucher.tsx
@@ -86,17 +86,17 @@ export default function DVoucher(
           {resolvedIconProps && (
             <DIcon {...resolvedIconProps} />
           )}
-          <div className="text-center">
-            <h3 className="mb-2">{title}</h3>
-            <p className="m-0">{message}</p>
+          <div className="d-voucher-title-group">
+            <h3 className="d-voucher-title">{title}</h3>
+            <p className="d-voucher-message">{message}</p>
           </div>
         </div>
         {amount && (
           <div className="d-voucher-amount">
             <div
               className={classNames(
-                'text-center fw-bold fs-3',
-                amountDetails ? 'mb-1' : 'm-0',
+                'd-voucher-amount-value',
+                { 'd-voucher-amount-value-with-details': !!amountDetails },
               )}
             >
               {amount}
@@ -105,9 +105,9 @@ export default function DVoucher(
           </div>
         )}
 
-        <hr className="my-4" />
+        <hr className="d-voucher-divider" />
         {children}
-        <hr className="my-4" />
+        <hr className="d-voucher-divider" />
 
         <div className="d-voucher-footer">
           <DButton

--- a/src/style/components/_+import.scss
+++ b/src/style/components/_+import.scss
@@ -22,3 +22,10 @@
 @import "d-table-head";
 @import "d-input-phone";
 @import "d-credit-card";
+@import "d-confirm-modal";
+@import "d-data-state-wrapper";
+@import "d-error-boundary";
+@import "d-otp";
+@import "d-password-strength-meter";
+@import "d-dropdown";
+@import "d-stepper";

--- a/src/style/components/_+import.scss
+++ b/src/style/components/_+import.scss
@@ -27,5 +27,4 @@
 @import "d-error-boundary";
 @import "d-otp";
 @import "d-password-strength-meter";
-@import "d-dropdown";
 @import "d-stepper";

--- a/src/style/components/_d-box-file.scss
+++ b/src/style/components/_d-box-file.scss
@@ -69,6 +69,11 @@
   }
 }
 
+.d-box-file-empty-text {
+  margin: 0;
+  text-align: center;
+}
+
 .d-box-files {
   --#{$prefix}box-file-list-gap: #{$box-file-list-gap};
   --#{$prefix}box-file-list-padding: #{$box-file-list-padding};

--- a/src/style/components/_d-close.scss
+++ b/src/style/components/_d-close.scss
@@ -1,5 +1,6 @@
 .d-close {
   display: flex;
+  align-self: center;
   padding: 0;
   background: transparent;
   border: 0;

--- a/src/style/components/_d-confirm-modal.scss
+++ b/src/style/components/_d-confirm-modal.scss
@@ -1,0 +1,17 @@
+.confirm-modal {
+  --#{$prefix}confirm-modal-body-padding-y: var(--#{$prefix}ref-spacer-3);
+  --#{$prefix}confirm-modal-body-padding-x: var(--#{$prefix}ref-spacer-5);
+  --#{$prefix}confirm-modal-field-gap: var(--#{$prefix}ref-spacer-4);
+}
+
+.d-confirm-modal-body {
+  padding: var(--#{$prefix}confirm-modal-body-padding-y) var(--#{$prefix}confirm-modal-body-padding-x);
+}
+
+.d-confirm-modal-message {
+  margin-bottom: var(--#{$prefix}confirm-modal-field-gap);
+}
+
+.d-confirm-modal-field {
+  margin-bottom: var(--#{$prefix}confirm-modal-field-gap);
+}

--- a/src/style/components/_d-data-state-wrapper.scss
+++ b/src/style/components/_d-data-state-wrapper.scss
@@ -1,0 +1,47 @@
+.d-empty-state {
+  --#{$prefix}empty-state-padding: var(--#{$prefix}ref-spacer-5);
+  --#{$prefix}empty-state-spacing: var(--#{$prefix}ref-spacer-3);
+  --#{$prefix}empty-state-color: var(--#{$prefix}secondary);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--#{$prefix}empty-state-padding);
+  text-align: center;
+}
+
+.d-empty-state-icon {
+  margin-bottom: var(--#{$prefix}empty-state-spacing);
+  color: var(--#{$prefix}empty-state-color);
+}
+
+.d-empty-state-message {
+  margin-bottom: var(--#{$prefix}empty-state-spacing);
+  color: var(--#{$prefix}empty-state-color);
+}
+
+.d-error-state {
+  --#{$prefix}error-state-gap: var(--#{$prefix}ref-spacer-3);
+
+  display: flex;
+  gap: var(--#{$prefix}error-state-gap);
+  align-items: center;
+}
+
+.d-error-state-content {
+  flex: 1 1 auto;
+}
+
+.d-error-state-message {
+  margin-bottom: 0;
+}
+
+.d-loading-state {
+  --#{$prefix}loading-state-padding: var(--#{$prefix}ref-spacer-4);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--#{$prefix}loading-state-padding);
+}

--- a/src/style/components/_d-datepicker.scss
+++ b/src/style/components/_d-datepicker.scss
@@ -215,6 +215,12 @@
     }
   }
 
+  &-year-selector {
+    display: flex;
+    flex-grow: 1;
+    justify-content: center;
+  }
+
   &-day-selector {
     margin-bottom: var(--#{$prefix}ref-spacer-4);
 
@@ -285,6 +291,11 @@
   padding: 1rem;
   margin-bottom: 1rem;
   margin-top: -.5rem;
+}
+
+.datepicker-top-header-title {
+  margin-bottom: 0;
+  font-weight: var(--#{$prefix}fw-normal);
 }
 
 .react-datepicker__year,

--- a/src/style/components/_d-dropdown.scss
+++ b/src/style/components/_d-dropdown.scss
@@ -1,0 +1,4 @@
+.d-dropdown-item-content {
+  display: flex;
+  align-items: center;
+}

--- a/src/style/components/_d-dropdown.scss
+++ b/src/style/components/_d-dropdown.scss
@@ -1,4 +1,0 @@
-.d-dropdown-item-content {
-  display: flex;
-  align-items: center;
-}

--- a/src/style/components/_d-error-boundary.scss
+++ b/src/style/components/_d-error-boundary.scss
@@ -1,0 +1,7 @@
+.d-error-boundary-content {
+  --#{$prefix}error-boundary-gap: var(--#{$prefix}ref-spacer-2);
+
+  display: flex;
+  gap: var(--#{$prefix}error-boundary-gap);
+  align-items: center;
+}

--- a/src/style/components/_d-otp.scss
+++ b/src/style/components/_d-otp.scss
@@ -1,0 +1,54 @@
+.d-otp {
+  --#{$prefix}otp-content-gap: var(--#{$prefix}ref-spacer-6);
+  --#{$prefix}otp-content-padding-x: var(--#{$prefix}ref-spacer-3);
+  --#{$prefix}otp-content-padding-bottom: var(--#{$prefix}ref-spacer-4);
+  --#{$prefix}otp-footer-gap: var(--#{$prefix}ref-spacer-4);
+}
+
+.d-otp-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--#{$prefix}otp-content-gap);
+  padding: 0 var(--#{$prefix}otp-content-padding-x) var(--#{$prefix}otp-content-padding-bottom);
+}
+
+.d-otp-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--#{$prefix}otp-content-gap);
+}
+
+.d-otp-divider {
+  margin: 0;
+}
+
+.d-otp-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--#{$prefix}otp-footer-gap);
+  align-items: center;
+
+  @include media-breakpoint-up(lg) {
+    flex-direction: row;
+  }
+}
+
+.d-otp-contact {
+  margin-bottom: 0;
+  font-size: .875em;
+
+  @include media-breakpoint-up(lg) {
+    margin-left: auto;
+  }
+}
+
+.d-otp-countdown {
+  display: flex;
+  gap: var(--#{$prefix}ref-spacer-2);
+  align-items: center;
+}
+
+.d-otp-countdown-text {
+  flex: 1 1 auto;
+  margin-bottom: 0;
+}

--- a/src/style/components/_d-password-strength-meter.scss
+++ b/src/style/components/_d-password-strength-meter.scss
@@ -1,0 +1,76 @@
+.d-password-strength-meter {
+  --#{$prefix}password-strength-meter-margin-top: var(--#{$prefix}ref-spacer-2);
+
+  margin-top: var(--#{$prefix}password-strength-meter-margin-top);
+}
+
+.d-password-strength-bar {
+  --#{$prefix}password-strength-bar-height: 8px;
+  --#{$prefix}password-strength-bar-radius: var(--#{$prefix}border-radius-lg);
+  --#{$prefix}password-strength-bar-bg: var(--#{$prefix}gray-100);
+  --#{$prefix}password-strength-bar-margin-bottom: var(--#{$prefix}ref-spacer-2);
+
+  width: 100%;
+  height: var(--#{$prefix}password-strength-bar-height);
+  margin-bottom: var(--#{$prefix}password-strength-bar-margin-bottom);
+  overflow: hidden;
+  background: var(--#{$prefix}password-strength-bar-bg);
+  border-radius: var(--#{$prefix}password-strength-bar-radius);
+}
+
+.d-password-strength-bar-fill {
+  height: 100%;
+  transition: width .3s ease-in-out;
+
+  &.is-empty {
+    background: var(--#{$prefix}gray-200);
+  }
+
+  &.is-weak {
+    background: var(--#{$prefix}danger);
+  }
+
+  &.is-fair {
+    background: var(--#{$prefix}warning);
+  }
+
+  &.is-good {
+    background: var(--#{$prefix}info);
+  }
+
+  &.is-strong {
+    background: var(--#{$prefix}success);
+  }
+}
+
+.d-password-check-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--#{$prefix}ref-spacer-2);
+  padding-left: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.d-password-check-item {
+  --#{$prefix}password-check-item-color: var(--#{$prefix}gray-600);
+
+  display: flex;
+  gap: var(--#{$prefix}ref-spacer-2);
+  align-items: flex-start;
+  font-size: .875em;
+  color: var(--#{$prefix}password-check-item-color);
+
+  &.is-valid {
+    color: var(--#{$prefix}success);
+  }
+}
+
+.d-password-check-item-icon {
+  flex-shrink: 0;
+  color: var(--#{$prefix}gray-300);
+}
+
+.d-password-check-item.is-valid .d-password-check-item-icon {
+  color: var(--#{$prefix}success);
+}

--- a/src/style/components/_d-popover.scss
+++ b/src/style/components/_d-popover.scss
@@ -11,5 +11,9 @@
     &:focus-visible {
       outline: 0;
     }
+
+    &.d-popover-content-fill {
+      width: 100%;
+    }
   }
 }

--- a/src/style/components/_d-stepper.scss
+++ b/src/style/components/_d-stepper.scss
@@ -1,0 +1,8 @@
+// Semantic hook classes for theming. The mobile/desktop toggle itself relies on
+// Bootstrap's responsive display utilities (d-{breakpoint}-none / d-{breakpoint}-block)
+// because the breakpoint is dynamic (component prop) and CSS custom properties
+// cannot be read inside media queries.
+.d-stepper-mobile,
+.d-stepper-desktop {
+  width: 100%;
+}

--- a/src/style/components/_d-tabs.scss
+++ b/src/style/components/_d-tabs.scss
@@ -1,3 +1,21 @@
+.d-tabs {
+  display: flex;
+  width: 100%;
+}
+
+.d-tabs-column {
+  flex-direction: column;
+}
+
+.d-tabs-nav-vertical {
+  flex-direction: column;
+  align-items: center;
+}
+
+.d-tabs-content {
+  width: 100%;
+}
+
 .nav-toggle-button-group {
   --#{$prefix}toggle-button-group-border-color: var(--#{$prefix}gray-50);
   --#{$prefix}toggle-button-group-border-radius: 4rem;

--- a/src/style/components/_d-voucher.scss
+++ b/src/style/components/_d-voucher.scss
@@ -5,6 +5,9 @@
   --#{$prefix}voucher-amount-rounded: var(--#{$prefix}ref-spacer-4);
   --#{$prefix}voucher-footer-gap: var(--#{$prefix}ref-spacer-4);
   --#{$prefix}voucher-margin: 0 0 var(--#{$prefix}ref-spacer-4) 0;
+  --#{$prefix}voucher-title-margin-bottom: var(--#{$prefix}ref-spacer-2);
+  --#{$prefix}voucher-amount-value-margin: var(--#{$prefix}ref-spacer-1);
+  --#{$prefix}voucher-divider-margin: var(--#{$prefix}ref-spacer-4);
 }
 
 .d-voucher-header {
@@ -27,4 +30,31 @@
   display: flex;
   gap: var(--#{$prefix}voucher-footer-gap);
   justify-content: flex-start;
+}
+
+.d-voucher-title-group {
+  text-align: center;
+}
+
+.d-voucher-title {
+  margin-bottom: var(--#{$prefix}voucher-title-margin-bottom);
+}
+
+.d-voucher-message {
+  margin: 0;
+}
+
+.d-voucher-amount-value {
+  margin: 0;
+  font-size: var(--#{$prefix}fs-3);
+  font-weight: var(--#{$prefix}fw-bold);
+  text-align: center;
+
+  &.d-voucher-amount-value-with-details {
+    margin-bottom: var(--#{$prefix}voucher-amount-value-margin);
+  }
+}
+
+.d-voucher-divider {
+  margin: var(--#{$prefix}voucher-divider-margin) 0;
 }


### PR DESCRIPTION
## Resumen

Reemplaza las clases utilitarias de Bootstrap usadas directamente en el JSX de varios componentes por clases semánticas propias del componente, respaldadas por CSS custom properties (tokens), siguiendo el patrón ya existente en el design system (`--bs-{componente}-{propiedad}` referenciando `--bs-ref-spacer-N`, colores y tipografía).

Closes #1132

## Componentes afectados

1. DBoxFile
2. DConfirmModal
3. DDataStateWrapper (EmptyState/ErrorState/LoadingState)
4. DDatePicker
5. DDropdown
6. DErrorBoundary
7. DModal
8. DOffcanvas
9. DOtp (+ OtpCountdown)
10. DPasswordStrengthMeter (3 archivos)
11. DPopover
12. DStepper
13. DTabs
14. DToastContainer
15. DVoucher

## Detalles

- Nuevos parciales SCSS en `src/style/components/`: `_d-confirm-modal`, `_d-data-state-wrapper`, `_d-error-boundary`, `_d-otp`, `_d-password-strength-meter`, `_d-dropdown`, `_d-stepper` (registrados en `_+import.scss`).
- Parciales extendidos: `_d-box-file`, `_d-voucher`, `_d-popover`, `_d-tabs`, `_d-close`, `_d-datepicker`.
- Estados dinámicos (validez/fuerza de contraseña) ahora usan clases modificadoras (`is-valid`, `is-empty/is-weak/is-fair/is-good/is-strong`) en vez de clases de color condicionales en el JSX.
- `DStepper` mantiene las utilidades responsive `d-{breakpoint}-none/block` de Bootstrap (breakpoint dinámico vía prop, no tokenizable en media queries) y solo agrega clases de hook para theming.
- Resultado visual idéntico al actual (retrocompatible); se actualizaron únicamente los specs que aseraban los nombres de clase antiguos (`DTabs.spec.tsx`, `DPopover.spec.tsx`).

## Validación

- [x] `npm run build:scss` compila sin errores.
- [x] `stylelint` sobre los SCSS tocados sin errores.
- [x] `eslint` sobre `src/**/*.{ts,tsx}` sin errores.
- [x] Suite completa de Jest: 530/530 tests pasando.
