### PR TITLE
feat(DInputCurrency): add minValue and maxValue props for input value clamping

### DIFF
--- a/src/components/DInputCurrency/DInputCurrency.spec.tsx
+++ b/src/components/DInputCurrency/DInputCurrency.spec.tsx
@@ -1,6 +1,33 @@
+import { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import DInputCurrency from '.';
 import { DContextProvider } from '../../contexts';
+
+function ControlledDInputCurrency({
+  initialValue,
+  minValue,
+  maxValue,
+  onChange,
+}: {
+  initialValue?: number;
+  minValue?: number;
+  maxValue?: number;
+  onChange: (value?: number) => void;
+}) {
+  const [value, setValue] = useState<number | undefined>(initialValue);
+
+  return (
+    <DInputCurrency
+      value={value}
+      minValue={minValue}
+      maxValue={maxValue}
+      onChange={(newValue) => {
+        setValue(newValue);
+        onChange(newValue);
+      }}
+    />
+  );
+}
 
 describe('<DInputCurrency />', () => {
   it('should render base currency', () => {
@@ -104,5 +131,80 @@ describe('<DInputCurrency />', () => {
     expect(handleBlur).toHaveBeenCalled();
 
     expect(input).toHaveValue('1,234.56');
+  });
+
+  it('clamps the value to maxValue on blur', () => {
+    const handleChange = jest.fn();
+
+    render(
+      <ControlledDInputCurrency
+        initialValue={50}
+        minValue={0}
+        maxValue={100}
+        onChange={handleChange}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '500' } });
+    fireEvent.blur(input);
+
+    expect(handleChange).toHaveBeenLastCalledWith(100);
+    expect(input).toHaveValue('100.00');
+  });
+
+  it('clamps the value to minValue on blur', () => {
+    const handleChange = jest.fn();
+
+    render(
+      <ControlledDInputCurrency
+        initialValue={50}
+        minValue={0}
+        maxValue={100}
+        onChange={handleChange}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '-20' } });
+    fireEvent.blur(input);
+
+    expect(handleChange).toHaveBeenLastCalledWith(0);
+    expect(input).toHaveValue('0.00');
+  });
+
+  it('does not clamp the value when minValue/maxValue are not defined', () => {
+    const handleChange = jest.fn();
+
+    render(
+      <ControlledDInputCurrency
+        initialValue={50}
+        onChange={handleChange}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '999999' } });
+    fireEvent.blur(input);
+
+    expect(handleChange).toHaveBeenCalledWith(999999);
+    expect(input).toHaveValue('999,999.00');
+  });
+
+  it('leaves invalid/valid state fully controlled by the consumer', () => {
+    render(
+      <DInputCurrency
+        value={500}
+        minValue={0}
+        maxValue={100}
+        invalid
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveClass('is-invalid');
   });
 });

--- a/src/components/DInputCurrency/DInputCurrency.tsx
+++ b/src/components/DInputCurrency/DInputCurrency.tsx
@@ -55,6 +55,8 @@ function DInputCurrency(
     onChange,
     onBlur,
     ref,
+    minValue,
+    maxValue,
   );
 
   return (

--- a/src/hooks/tests/useInputCurrency.spec.ts
+++ b/src/hooks/tests/useInputCurrency.spec.ts
@@ -94,4 +94,97 @@ describe('useInputCurrency', () => {
     const { result } = renderHook(() => useInputCurrency(currencyOptions, 100));
     expect(result.current.inputRef).toHaveProperty('current');
   });
+
+  it('should clamp initial value above maxValue', () => {
+    const { result } = renderHook(
+      () => useInputCurrency(currencyOptions, 500, undefined, undefined, undefined, undefined, 0, 100),
+    );
+    expect(result.current.innerValue).toBe('100.00');
+  });
+
+  it('should clamp initial value below minValue', () => {
+    const { result } = renderHook(
+      () => useInputCurrency(currencyOptions, -50, undefined, undefined, undefined, undefined, 0, 100),
+    );
+    expect(result.current.innerValue).toBe('0.00');
+  });
+
+  it('should clamp value to maxValue on blur and call onChange', () => {
+    const onChange = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ value }) => useInputCurrency(currencyOptions, value, undefined, onChange, undefined, undefined, 0, 100),
+      { initialProps: { value: 50 } },
+    );
+    act(() => {
+      result.current.handleOnChange('500');
+    });
+    rerender({ value: 500 });
+
+    act(() => {
+      result.current.handleOnBlur({ stopPropagation: jest.fn() } as never);
+    });
+    expect(onChange).toHaveBeenLastCalledWith(100);
+
+    rerender({ value: 100 });
+    expect(result.current.innerValue).toBe('100.00');
+  });
+
+  it('should clamp value to minValue on blur and call onChange', () => {
+    const onChange = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ value }) => useInputCurrency(currencyOptions, value, undefined, onChange, undefined, undefined, 0, 100),
+      { initialProps: { value: 50 } },
+    );
+    act(() => {
+      result.current.handleOnChange('-20');
+    });
+    rerender({ value: -20 });
+
+    act(() => {
+      result.current.handleOnBlur({ stopPropagation: jest.fn() } as never);
+    });
+    expect(onChange).toHaveBeenLastCalledWith(0);
+
+    rerender({ value: 0 });
+    expect(result.current.innerValue).toBe('0.00');
+  });
+
+  it('should not call onChange on blur when value is already within range', () => {
+    const onChange = jest.fn();
+    const { result } = renderHook(
+      () => useInputCurrency(currencyOptions, 50, undefined, onChange, undefined, undefined, 0, 100),
+    );
+    act(() => {
+      result.current.handleOnBlur({ stopPropagation: jest.fn() } as never);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should not clamp values when minValue/maxValue are not defined', () => {
+    const onChange = jest.fn();
+    const { result } = renderHook(
+      () => useInputCurrency(currencyOptions, 999999, undefined, onChange),
+    );
+    expect(result.current.innerValue).toBe('999,999.00');
+
+    act(() => {
+      result.current.handleOnBlur({ stopPropagation: jest.fn() } as never);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(result.current.innerValue).toBe('999,999.00');
+  });
+
+  it('should only clamp against the defined bound when only minValue is provided', () => {
+    const { result } = renderHook(
+      () => useInputCurrency(currencyOptions, -50, undefined, undefined, undefined, undefined, 0),
+    );
+    expect(result.current.innerValue).toBe('0.00');
+  });
+
+  it('should only clamp against the defined bound when only maxValue is provided', () => {
+    const { result } = renderHook(
+      () => useInputCurrency(currencyOptions, 500, undefined, undefined, undefined, undefined, undefined, 100),
+    );
+    expect(result.current.innerValue).toBe('100.00');
+  });
 });

--- a/src/hooks/useInputCurrency.ts
+++ b/src/hooks/useInputCurrency.ts
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import currency from 'currency.js';
@@ -33,13 +34,33 @@ export default function useInputCurrency(
   onChange?: (value?: number) => void,
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void,
   ref?: ForwardedRef<HTMLInputElement>,
+  minValue?: number,
+  maxValue?: number,
 ) {
   const inputRef = useProvidedRefOrCreate(ref as RefObject<HTMLInputElement | null>);
 
+  const clampValue = useCallback((newValue?: number) => {
+    if (newValue === undefined) {
+      return newValue;
+    }
+
+    let clampedValue = newValue;
+
+    if (minValue !== undefined) {
+      clampedValue = Math.max(clampedValue, minValue);
+    }
+
+    if (maxValue !== undefined) {
+      clampedValue = Math.min(clampedValue, maxValue);
+    }
+
+    return clampedValue;
+  }, [minValue, maxValue]);
+
   const [innerType, setInnerType] = useState('text');
-  const [innerNumber, setInnerNumber] = useState<number | undefined>(value);
+  const [innerNumber, setInnerNumber] = useState<number | undefined>(clampValue(value));
   const [innerString, setInnerString] = useState<string | undefined>(
-    formatValue(value, currencyOptions),
+    formatValue(clampValue(value), currencyOptions),
   );
 
   const handleOnFocus = useCallback((event: FocusEvent<HTMLInputElement>) => {
@@ -51,8 +72,17 @@ export default function useInputCurrency(
   const handleOnBlur = useCallback((event: FocusEvent<HTMLInputElement>) => {
     event.stopPropagation();
     setInnerType('text');
+
+    const clampedNumber = clampValue(innerNumber);
+
+    if (clampedNumber !== innerNumber) {
+      setInnerNumber(clampedNumber);
+      setInnerString(formatValue(clampedNumber, currencyOptions));
+      onChange?.(clampedNumber);
+    }
+
     onBlur?.(event);
-  }, [onBlur]);
+  }, [onBlur, innerNumber, clampValue, currencyOptions, onChange]);
 
   const generateStyleVariables = useMemo<CustomStyles>(() => ({
     [`--${PREFIX_BS}input-currency-component-symbol-color`]: `var(--${PREFIX_BS}secondary)`,
@@ -73,7 +103,14 @@ export default function useInputCurrency(
     }
   }, [currencyOptions, onChange, innerNumber]);
 
+  const isMountedRef = useRef(false);
+
   useEffect(() => {
+    if (!isMountedRef.current) {
+      isMountedRef.current = true;
+      return;
+    }
+
     if (value !== innerNumber) {
       setInnerNumber(value);
       setInnerString(formatValue(value, currencyOptions));

--- a/stories/components/DInputCurrency.stories.tsx
+++ b/stories/components/DInputCurrency.stories.tsx
@@ -78,7 +78,7 @@ and so it does [Input Group CSS Variables](https://getbootstrap.com/docs/5.3/for
       table: { category: 'Content' },
     },
     value: {
-      control: 'number',
+      control: false,
       type: 'number',
       description: 'The value of the input',
       table: { category: 'Content' },
@@ -229,8 +229,14 @@ export const Default: Story = {
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
-    minValue: 0,
-    maxValue: 100000,
+    minValue: undefined,
+    maxValue: undefined,
+    readOnly: false,
+    disabled: false,
+    loading: false,
+    invalid: false,
+    valid: false,
+    floatingLabel: false,
   },
 };
 
@@ -240,8 +246,6 @@ export const Invalid: Story = {
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
-    minValue: 0,
-    maxValue: 100000,
     invalid: true,
   },
 };
@@ -252,8 +256,6 @@ export const Valid: Story = {
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
-    minValue: 0,
-    maxValue: 100000,
     valid: true,
   },
 };
@@ -264,8 +266,6 @@ export const Disabled: Story = {
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
-    minValue: 0,
-    maxValue: 100000,
     disabled: true,
   },
 };
@@ -276,9 +276,25 @@ export const WithCurrencyCode: Story = {
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
-    minValue: 0,
-    maxValue: 100000,
     currencyCode: 'CLP',
+  },
+};
+
+export const WithRangeMinMax: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'The component can receive a min and max value to limit the input value. This example shows the component with a min value of <strong>$0.00</strong> and a max value of <strong>$10,000.00</strong>.',
+      },
+    },
+  },
+  args: {
+    id: 'componentId5',
+    label: 'Label',
+    placeholder: 'Placeholder',
+    value: undefined,
+    minValue: 0,
+    maxValue: 10000,
   },
 };
 
@@ -288,8 +304,6 @@ export const Floating: Story = {
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
-    minValue: 0,
-    maxValue: 100000,
     floatingLabel: true,
   },
 };

--- a/stories/components/DInputCurrency.stories.tsx
+++ b/stories/components/DInputCurrency.stories.tsx
@@ -289,7 +289,7 @@ export const WithRangeMinMax: Story = {
     },
   },
   args: {
-    id: 'componentId5',
+    id: 'componentId6',
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,
@@ -300,7 +300,7 @@ export const WithRangeMinMax: Story = {
 
 export const Floating: Story = {
   args: {
-    id: 'componentId6',
+    id: 'componentId7',
     label: 'Label',
     placeholder: 'Placeholder',
     value: undefined,


### PR DESCRIPTION
## Descripción

`DInputCurrency` ahora respeta los límites definidos en `minValue`/`maxValue`. Si el valor ingresado por el usuario es menor que `minValue`, se ajusta a `minValue`; si es mayor que `maxValue`, se ajusta a `maxValue`. Estas restricciones solo aplican cuando la prop correspondiente (`minValue` y/o `maxValue`) está definida; si no se definen, el input no tiene límites.

Los estados `invalid`/`valid` del componente siguen siendo controlados externamente por el consumidor (por ejemplo, con Formik u otro validador) y no se ven afectados por este cambio.

Closes #1134

## Cambios

- `useInputCurrency`: se agregan los parámetros `minValue`/`maxValue` y la lógica de ajuste del valor al rango definido (al montar y al perder el foco).
- `DInputCurrency`: se pasan `minValue`/`maxValue` al hook.
- Se agregan/actualizan tests unitarios en el hook y en el componente.
- Se actualiza el story de Storybook.

## Pruebas

- `npx jest src/hooks/tests/useInputCurrency.spec.ts src/components/DInputCurrency` ✅
- Suite completa (`npx jest`) ✅
- Lint (`eslint`) ✅
- Verificación manual en Storybook