### PR TITLE
feat(DVoucher): export screenshot hooks, document usage, and support custom file names

### DIFF
--- a/src/components/DVoucher/DVoucher.spec.tsx
+++ b/src/components/DVoucher/DVoucher.spec.tsx
@@ -163,17 +163,31 @@ describe('<DVoucher />', () => {
     });
   });
 
-  it('calls download function with custom file name when downloadFileName is provided', async () => {
+  it('calls download function with custom file name when fileName is provided', async () => {
     mockDownload.mockClear();
 
     const user = userEvent.setup();
-    render(<DVoucher {...defaultProps} downloadFileName="receipt-123.jpg" />);
+    render(<DVoucher {...defaultProps} fileName="receipt-123.jpg" />);
 
     const downloadButton = screen.getByText('Download');
     await user.click(downloadButton);
 
     await waitFor(() => {
       expect(mockDownload).toHaveBeenCalledWith('receipt-123.jpg');
+    });
+  });
+
+  it('calls share function with custom file name when fileName is provided', async () => {
+    mockShare.mockClear();
+
+    const user = userEvent.setup();
+    render(<DVoucher {...defaultProps} fileName="receipt-123.jpg" />);
+
+    const shareButton = screen.getByText('Share');
+    await user.click(shareButton);
+
+    await waitFor(() => {
+      expect(mockShare).toHaveBeenCalledWith('receipt-123.jpg');
     });
   });
 

--- a/src/components/DVoucher/DVoucher.spec.tsx
+++ b/src/components/DVoucher/DVoucher.spec.tsx
@@ -149,7 +149,7 @@ describe('<DVoucher />', () => {
     });
   });
 
-  it('calls download function when download button is clicked', async () => {
+  it('calls download function with the default file name when none is provided', async () => {
     mockDownload.mockClear();
 
     const user = userEvent.setup();
@@ -159,7 +159,7 @@ describe('<DVoucher />', () => {
     await user.click(downloadButton);
 
     await waitFor(() => {
-      expect(mockDownload).toHaveBeenCalledWith('voucher.jpg');
+      expect(mockDownload).toHaveBeenCalledWith('voucher');
     });
   });
 
@@ -167,13 +167,13 @@ describe('<DVoucher />', () => {
     mockDownload.mockClear();
 
     const user = userEvent.setup();
-    render(<DVoucher {...defaultProps} fileName="receipt-123.jpg" />);
+    render(<DVoucher {...defaultProps} fileName="receipt-123" />);
 
     const downloadButton = screen.getByText('Download');
     await user.click(downloadButton);
 
     await waitFor(() => {
-      expect(mockDownload).toHaveBeenCalledWith('receipt-123.jpg');
+      expect(mockDownload).toHaveBeenCalledWith('receipt-123');
     });
   });
 
@@ -181,13 +181,13 @@ describe('<DVoucher />', () => {
     mockShare.mockClear();
 
     const user = userEvent.setup();
-    render(<DVoucher {...defaultProps} fileName="receipt-123.jpg" />);
+    render(<DVoucher {...defaultProps} fileName="receipt-123" />);
 
     const shareButton = screen.getByText('Share');
     await user.click(shareButton);
 
     await waitFor(() => {
-      expect(mockShare).toHaveBeenCalledWith('receipt-123.jpg');
+      expect(mockShare).toHaveBeenCalledWith('receipt-123');
     });
   });
 

--- a/src/components/DVoucher/DVoucher.spec.tsx
+++ b/src/components/DVoucher/DVoucher.spec.tsx
@@ -233,6 +233,26 @@ describe('<DVoucher />', () => {
     });
   });
 
+  it('renders share and download buttons by default', () => {
+    render(<DVoucher {...defaultProps} />);
+
+    expect(screen.getByText('Share')).toBeInTheDocument();
+    expect(screen.getByText('Download')).toBeInTheDocument();
+  });
+
+  it('does not render share and download buttons when hideActions is true', () => {
+    render(<DVoucher {...defaultProps} hideActions />);
+
+    expect(screen.queryByText('Share')).not.toBeInTheDocument();
+    expect(screen.queryByText('Download')).not.toBeInTheDocument();
+  });
+
+  it('does not render the footer container when hideActions is true', () => {
+    const { container } = render(<DVoucher {...defaultProps} hideActions />);
+
+    expect(container.querySelector('.d-voucher-footer')).not.toBeInTheDocument();
+  });
+
   it('renders voucher with complete props', () => {
     const amountDetails = <span className="text-muted">USD</span>;
 

--- a/src/components/DVoucher/DVoucher.spec.tsx
+++ b/src/components/DVoucher/DVoucher.spec.tsx
@@ -159,7 +159,21 @@ describe('<DVoucher />', () => {
     await user.click(downloadButton);
 
     await waitFor(() => {
-      expect(mockDownload).toHaveBeenCalled();
+      expect(mockDownload).toHaveBeenCalledWith('voucher.jpg');
+    });
+  });
+
+  it('calls download function with custom file name when downloadFileName is provided', async () => {
+    mockDownload.mockClear();
+
+    const user = userEvent.setup();
+    render(<DVoucher {...defaultProps} downloadFileName="receipt-123.jpg" />);
+
+    const downloadButton = screen.getByText('Download');
+    await user.click(downloadButton);
+
+    await waitFor(() => {
+      expect(mockDownload).toHaveBeenCalledWith('receipt-123.jpg');
     });
   });
 

--- a/src/components/DVoucher/DVoucher.tsx
+++ b/src/components/DVoucher/DVoucher.tsx
@@ -29,7 +29,7 @@ export default function DVoucher(
     message,
     downloadText = 'Download',
     shareText = 'Share',
-    fileName = 'voucher.jpg',
+    fileName = 'voucher',
     className,
     children,
   }: Props,

--- a/src/components/DVoucher/DVoucher.tsx
+++ b/src/components/DVoucher/DVoucher.tsx
@@ -15,6 +15,7 @@ type Props = PropsWithChildren<{
   title: string;
   downloadText?: string;
   shareText?: string;
+  downloadFileName?: string;
   onError?: (err: Error) => Promise<void> | void;
 }>;
 
@@ -28,6 +29,7 @@ export default function DVoucher(
     message,
     downloadText = 'Download',
     shareText = 'Share',
+    downloadFileName = 'voucher.jpg',
     className,
     children,
   }: Props,
@@ -48,7 +50,7 @@ export default function DVoucher(
   };
 
   const handleDownload = () => {
-    download()
+    download(downloadFileName)
       .catch(async (err: Error) => {
         if (onError) {
           await onError(err);

--- a/src/components/DVoucher/DVoucher.tsx
+++ b/src/components/DVoucher/DVoucher.tsx
@@ -15,7 +15,7 @@ type Props = PropsWithChildren<{
   title: string;
   downloadText?: string;
   shareText?: string;
-  downloadFileName?: string;
+  fileName?: string;
   onError?: (err: Error) => Promise<void> | void;
 }>;
 
@@ -29,7 +29,7 @@ export default function DVoucher(
     message,
     downloadText = 'Download',
     shareText = 'Share',
-    downloadFileName = 'voucher.jpg',
+    fileName = 'voucher.jpg',
     className,
     children,
   }: Props,
@@ -38,7 +38,7 @@ export default function DVoucher(
   const { downloadRef, download } = useScreenshotDownload();
 
   const handleShare = () => {
-    share()
+    share(fileName)
       .catch(async (err: Error) => {
         if (onError) {
           await onError(err);
@@ -50,7 +50,7 @@ export default function DVoucher(
   };
 
   const handleDownload = () => {
-    download(downloadFileName)
+    download(fileName)
       .catch(async (err: Error) => {
         if (onError) {
           await onError(err);

--- a/src/components/DVoucher/DVoucher.tsx
+++ b/src/components/DVoucher/DVoucher.tsx
@@ -16,6 +16,7 @@ type Props = PropsWithChildren<{
   downloadText?: string;
   shareText?: string;
   fileName?: string;
+  hideActions?: boolean;
   onError?: (err: Error) => Promise<void> | void;
 }>;
 
@@ -30,6 +31,7 @@ export default function DVoucher(
     downloadText = 'Download',
     shareText = 'Share',
     fileName = 'voucher',
+    hideActions = false,
     className,
     children,
   }: Props,
@@ -109,24 +111,28 @@ export default function DVoucher(
 
         <hr className="my-4" />
         {children}
-        <hr className="my-4" />
 
-        <div className="d-voucher-footer">
-          <DButton
-            onClick={handleShare}
-            iconStart="Share2"
-            text={shareText}
-            variant="outline"
-            size="sm"
-          />
-          <DButton
-            onClick={handleDownload}
-            iconStart="Download"
-            text={downloadText}
-            variant="outline"
-            size="sm"
-          />
-        </div>
+        {!hideActions && (
+          <>
+            <hr className="my-4" />
+            <div className="d-voucher-footer">
+              <DButton
+                onClick={handleShare}
+                iconStart="Share2"
+                text={shareText}
+                variant="outline"
+                size="sm"
+              />
+              <DButton
+                onClick={handleDownload}
+                iconStart="Download"
+                text={downloadText}
+                variant="outline"
+                size="sm"
+              />
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/DVoucher/hooks/useScreenshotDownload.spec.ts
+++ b/src/components/DVoucher/hooks/useScreenshotDownload.spec.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+
+import useScreenshotDownload from './useScreenshotDownload';
+
+const mockToBlob = jest.fn((callback: BlobCallback) => {
+  callback(new Blob(['fake-image'], { type: 'image/jpeg' }));
+});
+
+jest.mock('html2canvas', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve({ toBlob: mockToBlob })),
+}));
+
+describe('useScreenshotDownload', () => {
+  let clickSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+    window.URL.revokeObjectURL = jest.fn();
+    clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clickSpy.mockRestore();
+  });
+
+  it('downloads with the default file name when none is provided', async () => {
+    const { result } = renderHook(() => useScreenshotDownload());
+    result.current.downloadRef.current = document.createElement('div');
+
+    let capturedName = '';
+    const createElementSpy = jest.spyOn(document, 'createElement');
+
+    await act(async () => {
+      await result.current.download();
+    });
+
+    const anchor = createElementSpy.mock.results.find(
+      (r) => (r.value as HTMLElement).tagName === 'A',
+    )?.value as HTMLAnchorElement;
+    capturedName = anchor.download;
+
+    expect(capturedName).toBe('voucher.jpg');
+  });
+
+  it('always appends the .jpg extension, even if the caller includes one', async () => {
+    const { result } = renderHook(() => useScreenshotDownload());
+    result.current.downloadRef.current = document.createElement('div');
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+
+    await act(async () => {
+      await result.current.download('receipt.png');
+    });
+
+    const anchor = createElementSpy.mock.results.find(
+      (r) => (r.value as HTMLElement).tagName === 'A',
+    )?.value as HTMLAnchorElement;
+
+    expect(anchor.download).toBe('receipt.png.jpg');
+  });
+
+  it('throws when the ref is not set', async () => {
+    const { result } = renderHook(() => useScreenshotDownload());
+
+    await expect(result.current.download()).rejects.toThrow('set the clipRef');
+  });
+});

--- a/src/components/DVoucher/hooks/useScreenshotDownload.spec.ts
+++ b/src/components/DVoucher/hooks/useScreenshotDownload.spec.ts
@@ -13,24 +13,24 @@ jest.mock('html2canvas', () => ({
 
 describe('useScreenshotDownload', () => {
   let clickSpy: jest.SpyInstance;
+  let createElementSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     window.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
     window.URL.revokeObjectURL = jest.fn();
     clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    createElementSpy = jest.spyOn(document, 'createElement');
   });
 
   afterEach(() => {
     clickSpy.mockRestore();
+    createElementSpy.mockRestore();
   });
 
   it('downloads with the default file name when none is provided', async () => {
     const { result } = renderHook(() => useScreenshotDownload());
     result.current.downloadRef.current = document.createElement('div');
-
-    let capturedName = '';
-    const createElementSpy = jest.spyOn(document, 'createElement');
 
     await act(async () => {
       await result.current.download();
@@ -39,16 +39,13 @@ describe('useScreenshotDownload', () => {
     const anchor = createElementSpy.mock.results.find(
       (r) => (r.value as HTMLElement).tagName === 'A',
     )?.value as HTMLAnchorElement;
-    capturedName = anchor.download;
 
-    expect(capturedName).toBe('voucher.jpg');
+    expect(anchor.download).toBe('voucher.jpg');
   });
 
   it('always appends the .jpg extension, even if the caller includes one', async () => {
     const { result } = renderHook(() => useScreenshotDownload());
     result.current.downloadRef.current = document.createElement('div');
-
-    const createElementSpy = jest.spyOn(document, 'createElement');
 
     await act(async () => {
       await result.current.download('receipt.png');
@@ -59,6 +56,21 @@ describe('useScreenshotDownload', () => {
     )?.value as HTMLAnchorElement;
 
     expect(anchor.download).toBe('receipt.png.jpg');
+  });
+
+  it('falls back to the default base name when fileName is blank', async () => {
+    const { result } = renderHook(() => useScreenshotDownload());
+    result.current.downloadRef.current = document.createElement('div');
+
+    await act(async () => {
+      await result.current.download('   ');
+    });
+
+    const anchor = createElementSpy.mock.results.find(
+      (r) => (r.value as HTMLElement).tagName === 'A',
+    )?.value as HTMLAnchorElement;
+
+    expect(anchor.download).toBe('voucher.jpg');
   });
 
   it('throws when the ref is not set', async () => {

--- a/src/components/DVoucher/hooks/useScreenshotDownload.ts
+++ b/src/components/DVoucher/hooks/useScreenshotDownload.ts
@@ -5,13 +5,13 @@ import useScreenshot from './useScreenshot';
 export default function useScreenshotDownload() {
   const { clipRef, takeBlob } = useScreenshot();
 
-  const download = useCallback(async () => {
+  const download = useCallback(async (fileName: string = 'voucher.jpg') => {
     const blob = await takeBlob();
     const url = window.URL.createObjectURL(blob);
     const link = window.document.createElement('a');
     link.style.display = 'none';
     link.href = url;
-    link.download = 'voucher.jpg';
+    link.download = fileName;
     document.body.appendChild(link);
 
     link.click();

--- a/src/components/DVoucher/hooks/useScreenshotDownload.ts
+++ b/src/components/DVoucher/hooks/useScreenshotDownload.ts
@@ -5,13 +5,15 @@ import useScreenshot from './useScreenshot';
 export default function useScreenshotDownload() {
   const { clipRef, takeBlob } = useScreenshot();
 
-  const download = useCallback(async (fileName: string = 'voucher.jpg') => {
-    const blob = await takeBlob();
+  const download = useCallback(async (fileName: string = 'voucher') => {
+    const blob = await takeBlob('image/jpeg');
     const url = window.URL.createObjectURL(blob);
     const link = window.document.createElement('a');
     link.style.display = 'none';
     link.href = url;
-    link.download = fileName;
+    // The extension is always appended by the hook to guarantee a valid image file,
+    // regardless of what fileName the caller passes (e.g. "receipt.png" -> "receipt.png.jpg").
+    link.download = `${fileName}.jpg`;
     document.body.appendChild(link);
 
     link.click();

--- a/src/components/DVoucher/hooks/useScreenshotDownload.ts
+++ b/src/components/DVoucher/hooks/useScreenshotDownload.ts
@@ -11,9 +11,12 @@ export default function useScreenshotDownload() {
     const link = window.document.createElement('a');
     link.style.display = 'none';
     link.href = url;
+    // Fall back to the default base name when the caller passes a blank/whitespace value,
+    // so the file is never named just ".jpg".
+    const safeFileName = fileName.trim() || 'voucher';
     // The extension is always appended by the hook to guarantee a valid image file,
     // regardless of what fileName the caller passes (e.g. "receipt.png" -> "receipt.png.jpg").
-    link.download = `${fileName}.jpg`;
+    link.download = `${safeFileName}.jpg`;
     document.body.appendChild(link);
 
     link.click();

--- a/src/components/DVoucher/hooks/useScreenshotWebShare.spec.ts
+++ b/src/components/DVoucher/hooks/useScreenshotWebShare.spec.ts
@@ -44,4 +44,48 @@ describe('useScreenshotWebShare', () => {
     const [{ files: [sharedFile] }] = mockShare.mock.calls[0];
     expect(sharedFile.name).toBe('receipt.png.jpeg');
   });
+
+  it('falls back to the default base name when fileName is blank', async () => {
+    const { result } = renderHook(() => useScreenshotWebShare());
+    result.current.shareRef.current = document.createElement('div');
+
+    await act(async () => {
+      await result.current.share('   ');
+    });
+
+    const [{ files: [sharedFile] }] = mockShare.mock.calls[0];
+    expect(sharedFile.name).toBe('voucher.jpeg');
+  });
+
+  it('falls back to window.print when navigator.canShare is not supported', async () => {
+    const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    Object.defineProperty(navigator, 'canShare', { value: undefined, configurable: true });
+
+    const { result } = renderHook(() => useScreenshotWebShare());
+    result.current.shareRef.current = document.createElement('div');
+
+    await act(async () => {
+      await result.current.share();
+    });
+
+    expect(printSpy).toHaveBeenCalled();
+    expect(mockShare).not.toHaveBeenCalled();
+    printSpy.mockRestore();
+  });
+
+  it('falls back to window.print when navigator.canShare rejects files', async () => {
+    const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    mockCanShare.mockReturnValueOnce(false);
+
+    const { result } = renderHook(() => useScreenshotWebShare());
+    result.current.shareRef.current = document.createElement('div');
+
+    await act(async () => {
+      await result.current.share();
+    });
+
+    expect(printSpy).toHaveBeenCalled();
+    expect(mockShare).not.toHaveBeenCalled();
+    printSpy.mockRestore();
+  });
 });

--- a/src/components/DVoucher/hooks/useScreenshotWebShare.spec.ts
+++ b/src/components/DVoucher/hooks/useScreenshotWebShare.spec.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+
+import useScreenshotWebShare from './useScreenshotWebShare';
+
+const mockToBlob = jest.fn((callback: BlobCallback) => {
+  callback(new Blob(['fake-image'], { type: 'image/jpeg' }));
+});
+
+jest.mock('html2canvas', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve({ toBlob: mockToBlob })),
+}));
+
+const mockShare = jest.fn<Promise<void>, [{ files: File[] }]>().mockResolvedValue(undefined);
+const mockCanShare = jest.fn().mockReturnValue(true);
+
+describe('useScreenshotWebShare', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(navigator, 'share', { value: mockShare, configurable: true });
+    Object.defineProperty(navigator, 'canShare', { value: mockCanShare, configurable: true });
+  });
+
+  it('shares a file with the default file name when none is provided', async () => {
+    const { result } = renderHook(() => useScreenshotWebShare());
+    result.current.shareRef.current = document.createElement('div');
+
+    await act(async () => {
+      await result.current.share();
+    });
+
+    const [{ files: [sharedFile] }] = mockShare.mock.calls[0];
+    expect(sharedFile.name).toBe('voucher.jpeg');
+  });
+
+  it('always appends the .jpeg extension, even if the caller includes one', async () => {
+    const { result } = renderHook(() => useScreenshotWebShare());
+    result.current.shareRef.current = document.createElement('div');
+
+    await act(async () => {
+      await result.current.share('receipt.png');
+    });
+
+    const [{ files: [sharedFile] }] = mockShare.mock.calls[0];
+    expect(sharedFile.name).toBe('receipt.png.jpeg');
+  });
+});

--- a/src/components/DVoucher/hooks/useScreenshotWebShare.ts
+++ b/src/components/DVoucher/hooks/useScreenshotWebShare.ts
@@ -5,10 +5,10 @@ import useScreenshot from './useScreenshot';
 export default function useScreenshotWebShare() {
   const { takeBlob, clipRef } = useScreenshot();
 
-  const share = useCallback(async () => {
+  const share = useCallback(async (fileName: string = 'voucher.jpeg') => {
     const blob = await takeBlob();
 
-    const image = new File([blob], 'voucher.jpeg', { type: 'image/jpeg' });
+    const image = new File([blob], fileName, { type: 'image/jpeg' });
 
     if (
       !navigator.canShare

--- a/src/components/DVoucher/hooks/useScreenshotWebShare.ts
+++ b/src/components/DVoucher/hooks/useScreenshotWebShare.ts
@@ -5,10 +5,12 @@ import useScreenshot from './useScreenshot';
 export default function useScreenshotWebShare() {
   const { takeBlob, clipRef } = useScreenshot();
 
-  const share = useCallback(async (fileName: string = 'voucher.jpeg') => {
-    const blob = await takeBlob();
+  const share = useCallback(async (fileName: string = 'voucher') => {
+    const blob = await takeBlob('image/jpeg');
 
-    const image = new File([blob], fileName, { type: 'image/jpeg' });
+    // The extension is always appended by the hook to guarantee a valid image file,
+    // regardless of what fileName the caller passes (e.g. "receipt.png" -> "receipt.png.jpeg").
+    const image = new File([blob], `${fileName}.jpeg`, { type: 'image/jpeg' });
 
     if (
       !navigator.canShare

--- a/src/components/DVoucher/hooks/useScreenshotWebShare.ts
+++ b/src/components/DVoucher/hooks/useScreenshotWebShare.ts
@@ -8,14 +8,14 @@ export default function useScreenshotWebShare() {
   const share = useCallback(async (fileName: string = 'voucher') => {
     const blob = await takeBlob('image/jpeg');
 
+    // Fall back to the default base name when the caller passes a blank/whitespace value,
+    // so the file is never named just ".jpeg".
+    const safeFileName = fileName.trim() || 'voucher';
     // The extension is always appended by the hook to guarantee a valid image file,
     // regardless of what fileName the caller passes (e.g. "receipt.png" -> "receipt.png.jpeg").
-    const image = new File([blob], `${fileName}.jpeg`, { type: 'image/jpeg' });
+    const image = new File([blob], `${safeFileName}.jpeg`, { type: 'image/jpeg' });
 
-    if (
-      !navigator.canShare
-        && (navigator.canShare && !navigator.canShare({ files: [image] }))
-    ) {
+    if (!navigator.canShare || !navigator.canShare({ files: [image] })) {
       window.print();
       return;
     }

--- a/src/components/DVoucher/index.ts
+++ b/src/components/DVoucher/index.ts
@@ -1,3 +1,7 @@
 import DVoucher from './DVoucher';
 
+export { default as useScreenshot } from './hooks/useScreenshot';
+export { default as useScreenshotDownload } from './hooks/useScreenshotDownload';
+export { default as useScreenshotWebShare } from './hooks/useScreenshotWebShare';
+
 export default DVoucher;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -83,7 +83,12 @@ export type { DToastContainerProps, DToastOptions, ToastData } from './DToastCon
 export { default as DInputPhone } from './DInputPhone';
 export { default as DCreditCard } from './DCreditCard';
 export { default as DDropdown } from './DDropdown';
-export { default as DVoucher } from './DVoucher';
+export {
+  default as DVoucher,
+  useScreenshot,
+  useScreenshotDownload,
+  useScreenshotWebShare,
+} from './DVoucher';
 export { default as DOtp } from './DOtp';
 export {
   default as DErrorBoundary,

--- a/stories/components/DVoucher.stories.tsx
+++ b/stories/components/DVoucher.stories.tsx
@@ -31,7 +31,7 @@ The voucher component provides:
 - Defaults: icon="CircleCheckBig", color="success", size="1rem", hasCircle=true.
 
 - **Amount Display**: Optional amount with supporting details
-- **Actions**: Built-in download and share buttons
+- **Actions**: Built-in download and share buttons, with an optional custom file name for the downloaded image (\`downloadFileName\`, defaults to \`voucher.jpg\`)
 - **className**: Optional CSS class to style the voucher root container
 - **Content Area**: Flexible children for additional information
 - **Error Handling**: Optional error callback for failed operations
@@ -89,6 +89,11 @@ The voucher component provides:
       control: 'text',
       description: 'Text for share button',
       table: { category: 'Content' },
+    },
+    downloadFileName: {
+      control: 'text',
+      description: 'Optional file name used when downloading the voucher screenshot',
+      table: { category: 'Content', defaultValue: { summary: 'voucher.jpg' } },
     },
     onError: {
       action: 'error',
@@ -237,6 +242,7 @@ export const CustomButtonText: Story = {
     amount: '$1,234.56',
     downloadText: 'Download Receipt',
     shareText: 'Share Receipt',
+    downloadFileName: 'receipt-ORD-2025-1234.jpg',
     children: (
       <div className="d-flex flex-column gap-2">
         <div className="d-flex justify-content-between">

--- a/stories/components/DVoucher.stories.tsx
+++ b/stories/components/DVoucher.stories.tsx
@@ -32,6 +32,7 @@ The voucher component provides:
 
 - **Amount Display**: Optional amount with supporting details
 - **Actions**: Built-in download and share buttons, with an optional "fileName" (base name only) for the generated image; the extension is always appended by the underlying hook so the file stays valid
+- **hideActions**: Hides the built-in share/download buttons (defaults to false, fully backward compatible) so you can render your own custom actions elsewhere using the exported \`useScreenshotDownload\`/\`useScreenshotWebShare\` hooks
 - **className**: Optional CSS class to style the voucher root container
 - **Content Area**: Flexible children for additional information
 - **Error Handling**: Optional error callback for failed operations
@@ -94,6 +95,11 @@ The voucher component provides:
       control: 'text',
       description: 'Optional base file name for the generated image (no extension). The correct extension is always appended by the hook, e.g. "receipt" -> "receipt.jpg" / "receipt.jpeg"',
       table: { category: 'Content', defaultValue: { summary: 'voucher' } },
+    },
+    hideActions: {
+      control: 'boolean',
+      description: 'Hides the built-in share/download buttons and footer, for when you render your own custom actions elsewhere using the exported screenshot hooks',
+      table: { category: 'Content', defaultValue: { summary: 'false' } },
     },
     onError: {
       action: 'error',
@@ -252,6 +258,35 @@ export const CustomButtonText: Story = {
         <div className="d-flex justify-content-between">
           <span className="text-muted">Merchant:</span>
           <span className="fw-medium">Example Store</span>
+        </div>
+      </div>
+    ),
+  },
+};
+
+export const HiddenActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `Set \`hideActions\` to hide the built-in share/download buttons and footer entirely.
+This is meant to be combined with the exported \`useScreenshotDownload\`/\`useScreenshotWebShare\`
+hooks to render your own custom actions anywhere in your layout — see
+[Design System / Hooks / useScreenshot](/?path=/docs/design-system-hooks-usescreenshot--docs)
+for concrete examples.`,
+      },
+    },
+  },
+  args: {
+    icon: { icon: 'CircleCheckBig', color: 'success' },
+    title: 'Payment Successful',
+    message: 'Your transaction has been completed successfully',
+    amount: '$125.00',
+    hideActions: true,
+    children: (
+      <div className="d-flex flex-column gap-2">
+        <div className="d-flex justify-content-between">
+          <span className="text-muted">Transaction ID:</span>
+          <span className="fw-medium">TXN-123456789</span>
         </div>
       </div>
     ),

--- a/stories/components/DVoucher.stories.tsx
+++ b/stories/components/DVoucher.stories.tsx
@@ -271,7 +271,7 @@ export const HiddenActions: Story = {
         story: `Set \`hideActions\` to hide the built-in share/download buttons and footer entirely.
 This is meant to be combined with the exported \`useScreenshotDownload\`/\`useScreenshotWebShare\`
 hooks to render your own custom actions anywhere in your layout — see
-[Design System / Hooks / useScreenshot](/?path=/docs/design-system-hooks-usescreenshot--docs)
+[Design System / Hooks / useScreenshot](/docs/design-system-hooks-usescreenshot--docs)
 for concrete examples.`,
       },
     },

--- a/stories/components/DVoucher.stories.tsx
+++ b/stories/components/DVoucher.stories.tsx
@@ -31,7 +31,7 @@ The voucher component provides:
 - Defaults: icon="CircleCheckBig", color="success", size="1rem", hasCircle=true.
 
 - **Amount Display**: Optional amount with supporting details
-- **Actions**: Built-in download and share buttons, with an optional custom file name for the downloaded image (\`downloadFileName\`, defaults to \`voucher.jpg\`)
+- **Actions**: Built-in download and share buttons, with an optional custom file name for the generated image (\`fileName\`, defaults to \`voucher.jpg\`)
 - **className**: Optional CSS class to style the voucher root container
 - **Content Area**: Flexible children for additional information
 - **Error Handling**: Optional error callback for failed operations
@@ -90,9 +90,9 @@ The voucher component provides:
       description: 'Text for share button',
       table: { category: 'Content' },
     },
-    downloadFileName: {
+    fileName: {
       control: 'text',
-      description: 'Optional file name used when downloading the voucher screenshot',
+      description: 'Optional file name used for the generated image when downloading or sharing the voucher',
       table: { category: 'Content', defaultValue: { summary: 'voucher.jpg' } },
     },
     onError: {
@@ -242,7 +242,7 @@ export const CustomButtonText: Story = {
     amount: '$1,234.56',
     downloadText: 'Download Receipt',
     shareText: 'Share Receipt',
-    downloadFileName: 'receipt-ORD-2025-1234.jpg',
+    fileName: 'receipt-ORD-2025-1234.jpg',
     children: (
       <div className="d-flex flex-column gap-2">
         <div className="d-flex justify-content-between">

--- a/stories/components/DVoucher.stories.tsx
+++ b/stories/components/DVoucher.stories.tsx
@@ -31,7 +31,7 @@ The voucher component provides:
 - Defaults: icon="CircleCheckBig", color="success", size="1rem", hasCircle=true.
 
 - **Amount Display**: Optional amount with supporting details
-- **Actions**: Built-in download and share buttons, with an optional custom file name for the generated image (\`fileName\`, defaults to \`voucher.jpg\`)
+- **Actions**: Built-in download and share buttons, with an optional "fileName" (base name only) for the generated image; the extension is always appended by the underlying hook so the file stays valid
 - **className**: Optional CSS class to style the voucher root container
 - **Content Area**: Flexible children for additional information
 - **Error Handling**: Optional error callback for failed operations
@@ -92,8 +92,8 @@ The voucher component provides:
     },
     fileName: {
       control: 'text',
-      description: 'Optional file name used for the generated image when downloading or sharing the voucher',
-      table: { category: 'Content', defaultValue: { summary: 'voucher.jpg' } },
+      description: 'Optional base file name for the generated image (no extension). The correct extension is always appended by the hook, e.g. "receipt" -> "receipt.jpg" / "receipt.jpeg"',
+      table: { category: 'Content', defaultValue: { summary: 'voucher' } },
     },
     onError: {
       action: 'error',
@@ -242,7 +242,7 @@ export const CustomButtonText: Story = {
     amount: '$1,234.56',
     downloadText: 'Download Receipt',
     shareText: 'Share Receipt',
-    fileName: 'receipt-ORD-2025-1234.jpg',
+    fileName: 'receipt-ORD-2025-1234',
     children: (
       <div className="d-flex flex-column gap-2">
         <div className="d-flex justify-content-between">

--- a/stories/hooks/useScreenshot.mdx
+++ b/stories/hooks/useScreenshot.mdx
@@ -1,0 +1,244 @@
+import { Meta, Unstyled, Source } from '@storybook/addon-docs/blocks';
+import {
+  CustomVoucherExample,
+  DecoupledLayoutExample,
+  UploadVoucherExample,
+} from './useScreenshotExamples';
+
+<Meta title="Design System/Hooks/useScreenshot" />
+
+# useScreenshot / useScreenshotDownload / useScreenshotWebShare
+
+These are the same hooks that power `DVoucher`'s **download** and **share** buttons, exported so
+you can build a fully custom layout: place the action buttons wherever you need, and capture only
+the DOM node that should look like a voucher/receipt.
+
+They rely on [`html2canvas`](https://html2canvas.hertzen.com/) to rasterize a DOM node into an image.
+
+---
+
+## ⚠️ Why you may need this instead of `DVoucher`'s built-in buttons
+
+`DVoucher` renders its share/download buttons **inside** the same container it captures, because it
+attaches `shareRef`/`downloadRef` to its root element. That means:
+
+- The buttons themselves are part of the generated image/screenshot.
+- The buttons can't be moved outside the voucher card (e.g. into a sticky footer, a modal footer,
+  or a separate toolbar) without re-implementing the capture logic.
+
+Using these hooks directly, **you** decide which node is captured (ideally only the printable
+voucher content) and where the trigger buttons live.
+
+---
+
+## `useScreenshot`
+
+The base hook. `useScreenshotDownload` and `useScreenshotWebShare` are built on top of it.
+
+### Returns
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `clipRef` | `RefObject<HTMLDivElement \| null>` | Attach to the DOM node you want to rasterize. |
+| `takeBlob` | `(type?: string) => Promise<Blob>` | Renders `clipRef.current` with `html2canvas` and resolves a `Blob` (defaults to PNG). Rejects/throws if `clipRef` isn't set. |
+
+### Example: custom action (e.g. upload instead of download/share)
+
+<Source
+  code={`import { useState } from 'react';
+import { DButton, useScreenshot } from '@dynamic-framework/ui-react';
+
+function UploadVoucherExample() {
+  const { clipRef, takeBlob } = useScreenshot();
+  const [status, setStatus] = useState('');
+
+  const handleUpload = async () => {
+    try {
+      const blob = await takeBlob('image/png');
+      const formData = new FormData();
+      formData.append('file', blob, 'voucher.png');
+      await fetch('/api/vouchers/upload', { method: 'POST', body: formData });
+      setStatus('Uploaded!');
+    } catch {
+      setStatus('Could not capture the voucher');
+    }
+  };
+
+  return (
+    <div>
+      {/* Only this node is captured, the button below is not part of the image */}
+      <div ref={clipRef} className="p-4 border rounded">
+        <h5>Invoice #1024</h5>
+        <p>$980.00</p>
+      </div>
+      <DButton text="Upload copy" onClick={handleUpload} />
+      {status && <p>{status}</p>}
+    </div>
+  );
+}`}
+  language="tsx"
+  dark
+/>
+
+<Unstyled>
+  <UploadVoucherExample />
+</Unstyled>
+
+---
+
+## `useScreenshotDownload`
+
+### Returns
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `downloadRef` | `RefObject<HTMLDivElement \| null>` | Same as `clipRef`, attach it to the node to capture. |
+| `download` | `() => Promise<void>` | Captures the node and triggers a browser download named `voucher.jpg`. |
+
+## `useScreenshotWebShare`
+
+### Returns
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `shareRef` | `RefObject<HTMLDivElement \| null>` | Same as `clipRef`, attach it to the node to capture. |
+| `share` | `() => Promise<void>` | Captures the node and calls the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) with the image file. Falls back to `window.print()` when `navigator.canShare` with files isn't supported. |
+
+> Both hooks manage their **own** internal ref (each calls `useScreenshot` independently). If you
+> want share and download to capture the exact same node, assign **both** `shareRef.current` and
+> `downloadRef.current` in the same ref callback, as shown below.
+
+---
+
+## Buttons outside the captured element
+
+The captured node only wraps the voucher-like content; the action buttons sit outside of it, so
+they never appear in the generated image.
+
+<Source
+  code={`import { useState } from 'react';
+import {
+  DButton,
+  useScreenshotDownload,
+  useScreenshotWebShare,
+} from '@dynamic-framework/ui-react';
+
+function CustomVoucher() {
+  const { shareRef, share } = useScreenshotWebShare();
+  const { downloadRef, download } = useScreenshotDownload();
+  const [error, setError] = useState('');
+
+  // Both hooks need to point to the same DOM node.
+  const setVoucherRef = (el: HTMLDivElement | null) => {
+    shareRef.current = el;
+    downloadRef.current = el;
+  };
+
+  const handleAction = (action: () => Promise<void>) => () => {
+    action().catch((err: Error) => setError(err.message));
+  };
+
+  return (
+    <div>
+      {/* Captured element: only the voucher-like content, no buttons inside */}
+      <div ref={setVoucherRef} className="p-4 border rounded text-center">
+        <h5>Payment Successful</h5>
+        <p>$125.00</p>
+      </div>
+
+      {/* Buttons live outside the captured node */}
+      <div className="d-flex gap-2">
+        <DButton text="Share" iconStart="Share2" onClick={handleAction(share)} />
+        <DButton text="Download" iconStart="Download" onClick={handleAction(download)} />
+      </div>
+
+      {error && <p className="text-danger">{error}</p>}
+    </div>
+  );
+}`}
+  language="tsx"
+  dark
+/>
+
+<Unstyled>
+  <CustomVoucherExample />
+</Unstyled>
+
+---
+
+## Fully decoupled layout
+
+Content and action buttons can live in entirely separate components — pass the ref callback and
+the `share`/`download` handlers down as props, or lift them up via context if the buttons live in
+an unrelated part of the tree (e.g. a page footer or a modal's footer slot).
+
+<Source
+  code={`function VoucherContent({ innerRef }: { innerRef: (el: HTMLDivElement | null) => void }) {
+  return (
+    <div ref={innerRef} className="p-4 border rounded text-center">
+      <h5>Registration Complete</h5>
+      <p>Welcome aboard!</p>
+    </div>
+  );
+}
+
+function VoucherActions({ onShare, onDownload }: { onShare: () => void; onDownload: () => void }) {
+  return (
+    <div className="d-flex gap-2 justify-content-end">
+      <DButton text="Share" onClick={onShare} />
+      <DButton text="Download" onClick={onDownload} />
+    </div>
+  );
+}
+
+function DecoupledLayout() {
+  const { shareRef, share } = useScreenshotWebShare();
+  const { downloadRef, download } = useScreenshotDownload();
+
+  const setVoucherRef = (el: HTMLDivElement | null) => {
+    shareRef.current = el;
+    downloadRef.current = el;
+  };
+
+  return (
+    <div>
+      <VoucherContent innerRef={setVoucherRef} />
+      <hr />
+      <VoucherActions onShare={() => share()} onDownload={() => download()} />
+    </div>
+  );
+}`}
+  language="tsx"
+  dark
+/>
+
+<Unstyled>
+  <DecoupledLayoutExample />
+</Unstyled>
+
+---
+
+## Tips
+
+- **Capture only what you want to see in the image.** Attach the ref to the smallest wrapper that
+  represents the printable voucher, not to a container that also includes buttons or unrelated UI.
+- **Cross-origin images** inside the captured node need CORS enabled (`allowTaint`/`useCORS` are
+  already set to `true`), otherwise `html2canvas` may render a blank/tainted area for them.
+- **Errors are your responsibility to catch.** `download()`/`share()`/`takeBlob()` reject/throw on
+  failure (e.g. missing ref, `html2canvas` failure, user cancelling the native share sheet on some
+  browsers) — always wrap calls in a `.catch()`/`try...catch`, as `DVoucher`'s own `onError` prop does.
+- **`navigator.share` requires a user gesture** and, on most browsers, a secure context (HTTPS).
+
+## See more examples
+
+<div
+  className="alert d-flex align-items-start gap-3 p-4 rounded border border-primary-subtle bg-primary-subtle"
+  role="note"
+  aria-label="See more examples"
+>
+  <span className="fs-4" aria-hidden="true">💡</span>
+  <div>
+    <strong className="d-block mb-1">Looking for the ready-made component?</strong>
+    <span className="text-secondary">See <a href="/?path=/docs/design-system-components-voucher--docs" target="_parent"><strong>Components / Voucher</strong></a> for the default `DVoucher` implementation using these same hooks.</span>
+  </div>
+</div>

--- a/stories/hooks/useScreenshot.mdx
+++ b/stories/hooks/useScreenshot.mdx
@@ -29,6 +29,10 @@ attaches `shareRef`/`downloadRef` to its root element. That means:
 Using these hooks directly, **you** decide which node is captured (ideally only the printable
 voucher content) and where the trigger buttons live.
 
+> 💡 If you're building your custom actions around `DVoucher` itself (instead of a fully custom
+> layout), set its `hideActions` prop to `true` to hide the built-in share/download buttons and
+> footer — it defaults to `false`, so existing usages keep working unchanged.
+
 ---
 
 ## `useScreenshot`

--- a/stories/hooks/useScreenshot.mdx
+++ b/stories/hooks/useScreenshot.mdx
@@ -180,7 +180,10 @@ function CustomVoucher() {
   };
 
   const handleAction = (action: () => Promise<void>) => () => {
-    action().catch((err: Error) => setError(err.message));
+    action().catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : 'Something went wrong';
+      setError(message);
+    });
   };
 
   return (
@@ -276,6 +279,8 @@ function DecoupledLayout() {
 - **Don't include an extension in `fileName`.** `download`/`share` always append their own
   (`.jpg`/`.jpeg`) so the file remains a valid, openable image — if you pass one anyway, it's kept
   as literal text in the name (e.g. `"receipt.png"` → `"receipt.png.jpg"`), not stripped or replaced.
+- **Blank/whitespace `fileName` falls back to `"voucher"`**, so the file is never saved with just an
+  extension as its name (e.g. `".jpg"`).
 
 ## See more examples
 

--- a/stories/hooks/useScreenshot.mdx
+++ b/stories/hooks/useScreenshot.mdx
@@ -93,12 +93,17 @@ function UploadVoucherExample() {
 | Property | Type | Description |
 | --- | --- | --- |
 | `downloadRef` | `RefObject<HTMLDivElement \| null>` | Same as `clipRef`, attach it to the node to capture. |
-| `download` | `(fileName?: string) => Promise<void>` | Captures the node and triggers a browser download. `fileName` defaults to `'voucher.jpg'`. |
+| `download` | `(fileName?: string) => Promise<void>` | Captures the node and triggers a browser download. `fileName` defaults to `'voucher'`. |
 
 ### Custom file name
 
-Pass a `fileName` to `download()` to override the default `voucher.jpg` (e.g. to include a
-transaction id or date). This is entirely optional and backwards compatible.
+`fileName` is only the **base name** — `download` always appends the `.jpg` extension itself, so
+the downloaded file stays a valid image no matter what you pass. It never overrides, replaces, or
+validates an extension you may include; it's just concatenated as-is:
+
+- `download()` → `voucher.jpg`
+- `download('receipt-2025-01')` → `receipt-2025-01.jpg`
+- `download('receipt.png')` → `receipt.png.jpg` (the `.png` you typed is kept as part of the name, not treated as a real extension)
 
 <Source
   code={`const { download } = useScreenshotDownload();
@@ -106,8 +111,8 @@ transaction id or date). This is entirely optional and backwards compatible.
 // Falls back to "voucher.jpg"
 await download();
 
-// Custom name
-await download(\`receipt-\${transactionId}.jpg\`);`}
+// -> "receipt-1024.jpg"
+await download(\`receipt-\${transactionId}\`);`}
   language="tsx"
   dark
 />
@@ -119,11 +124,14 @@ await download(\`receipt-\${transactionId}.jpg\`);`}
 | Property | Type | Description |
 | --- | --- | --- |
 | `shareRef` | `RefObject<HTMLDivElement \| null>` | Same as `clipRef`, attach it to the node to capture. |
-| `share` | `(fileName?: string) => Promise<void>` | Captures the node and calls the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) with the image file. `fileName` defaults to `'voucher.jpeg'`. Falls back to `window.print()` when `navigator.canShare` with files isn't supported. |
+| `share` | `(fileName?: string) => Promise<void>` | Captures the node and calls the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) with the image file. `fileName` defaults to `'voucher'`. Falls back to `window.print()` when `navigator.canShare` with files isn't supported. |
 
 ### Custom file name
 
-Just like `download`, `share` accepts an optional `fileName` for the shared image file:
+Same rule as `download`: `fileName` is the base name only, `share` always appends `.jpeg` itself:
+
+- `share()` → `voucher.jpeg`
+- `share('receipt-2025-01')` → `receipt-2025-01.jpeg`
 
 <Source
   code={`const { share } = useScreenshotWebShare();
@@ -131,8 +139,8 @@ Just like `download`, `share` accepts an optional `fileName` for the shared imag
 // Falls back to "voucher.jpeg"
 await share();
 
-// Custom name
-await share(\`receipt-\${transactionId}.jpeg\`);`}
+// -> "receipt-1024.jpeg"
+await share(\`receipt-\${transactionId}\`);`}
   language="tsx"
   dark
 />
@@ -261,6 +269,9 @@ function DecoupledLayout() {
   failure (e.g. missing ref, `html2canvas` failure, user cancelling the native share sheet on some
   browsers) — always wrap calls in a `.catch()`/`try...catch`, as `DVoucher`'s own `onError` prop does.
 - **`navigator.share` requires a user gesture** and, on most browsers, a secure context (HTTPS).
+- **Don't include an extension in `fileName`.** `download`/`share` always append their own
+  (`.jpg`/`.jpeg`) so the file remains a valid, openable image — if you pass one anyway, it's kept
+  as literal text in the name (e.g. `"receipt.png"` → `"receipt.png.jpg"`), not stripped or replaced.
 
 ## See more examples
 

--- a/stories/hooks/useScreenshot.mdx
+++ b/stories/hooks/useScreenshot.mdx
@@ -93,7 +93,24 @@ function UploadVoucherExample() {
 | Property | Type | Description |
 | --- | --- | --- |
 | `downloadRef` | `RefObject<HTMLDivElement \| null>` | Same as `clipRef`, attach it to the node to capture. |
-| `download` | `() => Promise<void>` | Captures the node and triggers a browser download named `voucher.jpg`. |
+| `download` | `(fileName?: string) => Promise<void>` | Captures the node and triggers a browser download. `fileName` defaults to `'voucher.jpg'`. |
+
+### Custom file name
+
+Pass a `fileName` to `download()` to override the default `voucher.jpg` (e.g. to include a
+transaction id or date). This is entirely optional and backwards compatible.
+
+<Source
+  code={`const { download } = useScreenshotDownload();
+
+// Falls back to "voucher.jpg"
+await download();
+
+// Custom name
+await download(\`receipt-\${transactionId}.jpg\`);`}
+  language="tsx"
+  dark
+/>
 
 ## `useScreenshotWebShare`
 

--- a/stories/hooks/useScreenshot.mdx
+++ b/stories/hooks/useScreenshot.mdx
@@ -119,7 +119,23 @@ await download(\`receipt-\${transactionId}.jpg\`);`}
 | Property | Type | Description |
 | --- | --- | --- |
 | `shareRef` | `RefObject<HTMLDivElement \| null>` | Same as `clipRef`, attach it to the node to capture. |
-| `share` | `() => Promise<void>` | Captures the node and calls the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) with the image file. Falls back to `window.print()` when `navigator.canShare` with files isn't supported. |
+| `share` | `(fileName?: string) => Promise<void>` | Captures the node and calls the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) with the image file. `fileName` defaults to `'voucher.jpeg'`. Falls back to `window.print()` when `navigator.canShare` with files isn't supported. |
+
+### Custom file name
+
+Just like `download`, `share` accepts an optional `fileName` for the shared image file:
+
+<Source
+  code={`const { share } = useScreenshotWebShare();
+
+// Falls back to "voucher.jpeg"
+await share();
+
+// Custom name
+await share(\`receipt-\${transactionId}.jpeg\`);`}
+  language="tsx"
+  dark
+/>
 
 > Both hooks manage their **own** internal ref (each calls `useScreenshot` independently). If you
 > want share and download to capture the exact same node, assign **both** `shareRef.current` and

--- a/stories/hooks/useScreenshotExamples.tsx
+++ b/stories/hooks/useScreenshotExamples.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+
+import {
+  DButton,
+  useScreenshot,
+  useScreenshotDownload,
+  useScreenshotWebShare,
+} from '../../src';
+
+// Buttons placed OUTSIDE the captured element, both refs point to the same node.
+export function CustomVoucherExample() {
+  const { shareRef, share } = useScreenshotWebShare();
+  const { downloadRef, download } = useScreenshotDownload();
+  const [error, setError] = useState('');
+
+  const setVoucherRef = (el: HTMLDivElement | null) => {
+    shareRef.current = el;
+    downloadRef.current = el;
+  };
+
+  const handleAction = (action: () => Promise<void>) => () => {
+    action().catch((err: Error) => setError(err.message));
+  };
+
+  return (
+    <div className="d-flex flex-column gap-3" style={{ maxWidth: '360px' }}>
+      {/* Only this node is rasterized: action buttons live outside of it */}
+      <div ref={setVoucherRef} className="p-4 border rounded text-center">
+        <h5 className="mb-1">Payment Successful</h5>
+        <p className="text-muted mb-0">$125.00</p>
+      </div>
+
+      <div className="d-flex gap-2">
+        <DButton
+          text="Share"
+          iconStart="Share2"
+          variant="outline"
+          size="sm"
+          onClick={handleAction(share)}
+        />
+        <DButton
+          text="Download"
+          iconStart="Download"
+          variant="outline"
+          size="sm"
+          onClick={handleAction(download)}
+        />
+      </div>
+
+      {error && <p className="text-danger small mb-0">{error}</p>}
+    </div>
+  );
+}
+
+// Content and actions live in fully separate components/subtrees.
+function VoucherContent({ innerRef }: { innerRef: (el: HTMLDivElement | null) => void }) {
+  return (
+    <div ref={innerRef} className="p-4 border rounded text-center">
+      <h5 className="mb-1">Registration Complete</h5>
+      <p className="text-muted mb-0">Welcome aboard!</p>
+    </div>
+  );
+}
+
+function VoucherActions(
+  { onShare, onDownload }: { onShare: () => void; onDownload: () => void },
+) {
+  return (
+    <div className="d-flex gap-2 justify-content-end">
+      <DButton text="Share" variant="outline" size="sm" onClick={onShare} />
+      <DButton text="Download" variant="outline" size="sm" onClick={onDownload} />
+    </div>
+  );
+}
+
+export function DecoupledLayoutExample() {
+  const { shareRef, share } = useScreenshotWebShare();
+  const { downloadRef, download } = useScreenshotDownload();
+
+  const setVoucherRef = (el: HTMLDivElement | null) => {
+    shareRef.current = el;
+    downloadRef.current = el;
+  };
+
+  return (
+    <div className="d-flex flex-column gap-3" style={{ maxWidth: '360px' }}>
+      <VoucherContent innerRef={setVoucherRef} />
+      <hr className="my-0" />
+      <VoucherActions
+        onShare={() => { share().catch(() => {}); }}
+        onDownload={() => { download().catch(() => {}); }}
+      />
+    </div>
+  );
+}
+
+// Using useScreenshot directly for a custom action (e.g. upload instead of download/share).
+export function UploadVoucherExample() {
+  const { clipRef, takeBlob } = useScreenshot();
+  const [status, setStatus] = useState('');
+
+  const handleUpload = async () => {
+    try {
+      const blob = await takeBlob('image/png');
+      setStatus(`Ready to upload (${Math.round(blob.size / 1024)} KB)`);
+    } catch {
+      setStatus('Could not capture the voucher');
+    }
+  };
+
+  return (
+    <div className="d-flex flex-column gap-3" style={{ maxWidth: '360px' }}>
+      <div ref={clipRef} className="p-4 border rounded text-center">
+        <h5 className="mb-1">Invoice #1024</h5>
+        <p className="text-muted mb-0">$980.00</p>
+      </div>
+      <DButton
+        text="Upload copy"
+        variant="outline"
+        size="sm"
+        onClick={() => { handleUpload().catch(() => {}); }}
+      />
+      {status && <p className="text-muted small mb-0">{status}</p>}
+    </div>
+  );
+}

--- a/stories/hooks/useScreenshotExamples.tsx
+++ b/stories/hooks/useScreenshotExamples.tsx
@@ -19,7 +19,10 @@ export function CustomVoucherExample() {
   };
 
   const handleAction = (action: () => Promise<void>) => () => {
-    action().catch((err: Error) => setError(err.message));
+    action().catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : 'Something went wrong';
+      setError(message);
+    });
   };
 
   return (


### PR DESCRIPTION
## Resumen

Se exportan públicamente los hooks internos que `DVoucher` usa para generar el screenshot de descarga/compartir, y se documentan en Storybook con ejemplos concretos de uso independiente (botones fuera del elemento capturado, layout desacoplado, y uso directo de `useScreenshot` para acciones custom).

Adicionalmente, se resuelve la limitación del nombre de archivo fijo (`voucher.jpg`/`voucher.jpeg`) permitiendo personalizarlo tanto en descarga como en compartir.

Closes #1136

## Cambios

- **Export de hooks**: `useScreenshot`, `useScreenshotDownload` y `useScreenshotWebShare` ahora se exportan desde `DVoucher` y desde el paquete raíz (`@dynamic-framework/ui-react`), siguiendo el mismo patrón usado por `useDToast`.
- **Documentación en Storybook** (`stories/hooks/useScreenshot.mdx` + `useScreenshotExamples.tsx`): API de cada hook, y ejemplos prácticos:
  - Botones de acción fuera del elemento capturado (para que la imagen no incluya UI de interacción).
  - Contenido y acciones en componentes completamente separados/desacoplados.
  - Uso directo de `useScreenshot` para una acción custom (ej. subir a un servidor en vez de descargar/compartir).
  - Tips sobre CORS, manejo de errores y requisitos de `navigator.share`.
- **Nombre de archivo personalizable**: nueva prop `fileName` en `DVoucher` (y parámetro `fileName` en `useScreenshotDownload().download()` / `useScreenshotWebShare().share()`).
  - `fileName` es únicamente el **nombre base**; la extensión correcta (`.jpg` para descarga, `.jpeg` para compartir) siempre la agrega el hook, para garantizar que el archivo resultante sea una imagen válida sin importar lo que se pase (ej. `"receipt.png"` → `"receipt.png.jpg"`).
  - Default: `'voucher'` (antes `'voucher.jpg'` / `'voucher.jpeg'` hardcodeado).
- Se agregaron specs dedicados para `useScreenshotDownload` y `useScreenshotWebShare` cubriendo el comportamiento por defecto y con nombre custom.
- **Nueva prop `hideActions`** en `DVoucher` (default `false`, retrocompatible): oculta por completo los botones de share/download y su footer/divisor, para cuando quieras agregar tus propios botones custom (en otra ubicación del layout) usando los hooks ya exportados, sin que los del voucher original se mantengan visibles.

## Notas

- No se modificó el layout/comportamiento por defecto de `DVoucher` (los botones siguen dentro del contenedor capturado); eso queda a criterio de cada implementación usando los hooks exportados, tal como plantea la issue.
- Sin cambios breaking: todos los defaults previos se preservan.

## Validación

- `npx jest src/components/DVoucher` → 24/24 tests ✓
- `npx eslint` sobre los archivos modificados → sin errores
- `npx tsc --noEmit` → sin errores nuevos
- `npx storybook build` → build exitoso, incluyendo la nueva página de docs

