### PR TITLE
fix(DInputCurrency): resolve symbol color with css class instead style

### DIFF
--- a/src/components/DInputCurrency/DInputCurrency.spec.tsx
+++ b/src/components/DInputCurrency/DInputCurrency.spec.tsx
@@ -21,9 +21,7 @@ describe('<DInputCurrency />', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <div
-          style="--bs-input-currency-component-symbol-color: var(--bs-secondary); --bs-input-currency-symbol-color: var(--bs-input-currency-component-symbol-color);"
-        >
+        <div>
           <label
             for="currencyTest"
           >
@@ -37,8 +35,8 @@ describe('<DInputCurrency />', () => {
               id="currencyTestInputStart"
             >
               <span
+                class="d-input-currency-symbol"
                 slot="input-start"
-                style="color: var(--bs-input-currency-symbol-color);"
               >
                 $
               </span>

--- a/src/components/DInputCurrency/DInputCurrency.tsx
+++ b/src/components/DInputCurrency/DInputCurrency.tsx
@@ -46,8 +46,6 @@ function DInputCurrency(
     handleOnFocus,
     handleOnChange,
     handleOnBlur,
-    generateStyleVariables,
-    generateSymbolStyleVariables,
   } = useInputCurrency(
     currencyOptions,
     value,
@@ -62,7 +60,6 @@ function DInputCurrency(
       ref={inputRef}
       value={innerValue}
       onChange={handleOnChange}
-      style={generateStyleVariables}
       inputMode="decimal"
       type={innerType}
       onFocus={handleOnFocus}
@@ -71,7 +68,7 @@ function DInputCurrency(
       inputStart={(
         <span
           slot="input-start"
-          style={generateSymbolStyleVariables}
+          className="d-input-currency-symbol"
         >
           {currencyCode || currencyOptions.symbol}
         </span>

--- a/src/hooks/tests/useInputCurrency.spec.ts
+++ b/src/hooks/tests/useInputCurrency.spec.ts
@@ -64,12 +64,6 @@ describe('useInputCurrency', () => {
     expect(result.current.innerValue).toBe('200.00');
   });
 
-  it('should generate style variables', () => {
-    const { result } = renderHook(() => useInputCurrency(currencyOptions, 100));
-    expect(result.current.generateStyleVariables).toHaveProperty('--bs-input-currency-component-symbol-color');
-    expect(result.current.generateSymbolStyleVariables).toHaveProperty('color');
-  });
-
   it('should call onFocus callback when input is focused', () => {
     const onFocus = jest.fn();
     const { result } = renderHook(() => useInputCurrency(currencyOptions, 100, onFocus));

--- a/src/hooks/useInputCurrency.ts
+++ b/src/hooks/useInputCurrency.ts
@@ -14,9 +14,6 @@ import type {
 import type { Options } from 'currency.js';
 
 import useProvidedRefOrCreate from './useProvidedRefOrCreate';
-import { PREFIX_BS } from '../components/config';
-
-import type { CustomStyles } from '../components/interface';
 
 function formatValue(value: number | undefined, currencyOptions: Options) {
   if (value === undefined) {
@@ -54,15 +51,6 @@ export default function useInputCurrency(
     onBlur?.(event);
   }, [onBlur]);
 
-  const generateStyleVariables = useMemo<CustomStyles>(() => ({
-    [`--${PREFIX_BS}input-currency-component-symbol-color`]: `var(--${PREFIX_BS}secondary)`,
-    [`--${PREFIX_BS}input-currency-symbol-color`]: `var(--${PREFIX_BS}input-currency-component-symbol-color)`,
-  }), []);
-
-  const generateSymbolStyleVariables = useMemo(() => ({
-    color: `var(--${PREFIX_BS}input-currency-symbol-color)`,
-  }), []);
-
   const handleOnChange = useCallback((newValue?: string) => {
     const newNumber = (newValue === undefined || newValue === '') ? undefined : Number(newValue);
 
@@ -92,7 +80,5 @@ export default function useInputCurrency(
     handleOnFocus,
     handleOnChange,
     handleOnBlur,
-    generateStyleVariables,
-    generateSymbolStyleVariables,
   };
 }

--- a/src/style/abstracts/variables/_+import.scss
+++ b/src/style/abstracts/variables/_+import.scss
@@ -94,4 +94,5 @@ $input-btn-border-width: var(--#{$prefix}border-width) !default;
 @import "box-file";
 @import "datepicker";
 @import "input-phone";
+@import "input-currency";
 // end custom

--- a/src/style/abstracts/variables/_input-currency.scss
+++ b/src/style/abstracts/variables/_input-currency.scss
@@ -1,0 +1,1 @@
+$input-currency-symbol-color: var(--#{$prefix}secondary) !default;

--- a/src/style/components/_+import.scss
+++ b/src/style/components/_+import.scss
@@ -22,3 +22,4 @@
 @import "d-table-head";
 @import "d-input-phone";
 @import "d-credit-card";
+@import "d-input-currency";

--- a/src/style/components/_d-input-currency.scss
+++ b/src/style/components/_d-input-currency.scss
@@ -1,0 +1,5 @@
+.d-input-currency-symbol {
+  --#{$prefix}input-currency-symbol-color: var(--#{$prefix}input-currency-component-symbol-color, #{$input-currency-symbol-color});
+
+  color: var(--#{$prefix}input-currency-symbol-color);
+}

--- a/stories/components/DInputCurrency.stories.tsx
+++ b/stories/components/DInputCurrency.stories.tsx
@@ -41,6 +41,55 @@ and so it does [Input Group CSS Variables](https://getbootstrap.com/docs/5.3/for
 | --${PREFIX_BS}form-text-color             | .form-text    | css color unit  | Hint color                   |
 | --${PREFIX_BS}form-control-text-align     | .form-control | css text align  | Input text align             |
 | --${PREFIX_BS}input-currency-symbol-color | .input-group  | css color unit  | Color of the currency symbol |
+| --${PREFIX_BS}icon-component-color        | .d-icon       | css color unit  | Color of the \`iconStart\`/\`iconEnd\` icon |
+
+## Changing the currency symbol color
+
+The currency symbol (the \`$\`, \`CLP\`, etc. rendered via \`inputStart\`) is wrapped in a
+\`.d-input-currency-symbol\` element whose color is controlled by two chained CSS variables, defined in
+the component's stylesheet (not via inline style):
+
+- \`--${PREFIX_BS}input-currency-component-symbol-color\`: the "public" variable meant to be overridden.
+  Defaults to \`var(--${PREFIX_BS}secondary)\` when not set.
+- \`--${PREFIX_BS}input-currency-symbol-color\`: the variable actually consumed by \`.d-input-currency-symbol\`'s
+  \`color\`. Falls back to the public variable above.
+
+Since these are regular CSS custom properties (no inline style involved), you can override the public
+variable from any ancestor selector, using either \`className\` or the \`style\` prop:
+
+\`\`\`jsx
+<DInputCurrency
+  className="my-input-currency"
+/>
+\`\`\`
+\`\`\`css
+.my-input-currency {
+  --${PREFIX_BS}input-currency-component-symbol-color: #dc3545;
+}
+\`\`\`
+
+\`\`\`jsx
+<DInputCurrency
+  style={{ '--${PREFIX_BS}input-currency-component-symbol-color': '#dc3545' }}
+/>
+\`\`\`
+
+## Changing the icon color
+
+\`DInputCurrency\` also supports \`iconStart\`/\`iconEnd\` (inherited from \`DInput\`), rendered via \`DIcon\`.
+Their color is controlled by the \`--${PREFIX_BS}icon-component-color\` CSS variable (defined on the
+internal \`.d-icon\` element), which is **not** set via inline style, so it can be safely scoped with a
+regular \`className\`:
+
+\`\`\`css
+.my-input-currency .d-icon {
+  --${PREFIX_BS}icon-component-color: #dc3545;
+}
+\`\`\`
+
+\`\`\`jsx
+<DInputCurrency className="my-input-currency" iconStart="Search" />
+\`\`\`
         `,
       },
     },
@@ -291,5 +340,112 @@ export const Floating: Story = {
     minValue: 0,
     maxValue: 100000,
     floatingLabel: true,
+  },
+};
+
+export const WithIconColor: Story = {
+  args: {
+    id: 'componentId7',
+    label: 'Label',
+    placeholder: 'Placeholder',
+    value: undefined,
+    minValue: 0,
+    maxValue: 100000,
+    iconEnd: 'Search',
+    className: 'd-input-currency-icon-color-demo',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Changes the color of the \`iconEnd\` icon using \`className\` to scope the
+\`--${PREFIX_BS}icon-component-color\` CSS variable, without affecting the currency symbol color.
+
+\`\`\`css
+.d-input-currency-icon-color-demo .d-icon {
+  --${PREFIX_BS}icon-component-color: #dc3545;
+}
+\`\`\`
+        `,
+      },
+    },
+  },
+  render: function Render(args: ComponentProps<typeof DInputCurrency>) {
+    const [innerValue, setInnerValue] = useState<number | undefined>(args.value);
+
+    return (
+      <DContextProvider>
+        <style>
+          {`
+            .d-input-currency-icon-color-demo .d-icon {
+              --${PREFIX_BS}icon-component-color: #dc3545;
+            }
+          `}
+        </style>
+        <DInputCurrency
+          {...args}
+          value={innerValue}
+          onChange={(newValue) => {
+            setInnerValue(newValue);
+            if (args.onChange) {
+              args.onChange(newValue);
+            }
+          }}
+        />
+      </DContextProvider>
+    );
+  },
+};
+
+export const WithSymbolColor: Story = {
+  args: {
+    id: 'componentId8',
+    label: 'Label',
+    placeholder: 'Placeholder',
+    value: undefined,
+    minValue: 0,
+    maxValue: 100000,
+    className: 'd-input-currency-symbol-color-demo',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Changes the currency symbol color using \`className\` to scope the
+\`--${PREFIX_BS}input-currency-component-symbol-color\` CSS variable.
+
+\`\`\`css
+.d-input-currency-symbol-color-demo {
+  --${PREFIX_BS}input-currency-component-symbol-color: #dc3545;
+}
+\`\`\`
+        `,
+      },
+    },
+  },
+  render: function Render(args: ComponentProps<typeof DInputCurrency>) {
+    const [innerValue, setInnerValue] = useState<number | undefined>(args.value);
+
+    return (
+      <DContextProvider>
+        <style>
+          {`
+            .d-input-currency-symbol-color-demo {
+              --${PREFIX_BS}input-currency-component-symbol-color: #dc3545;
+            }
+          `}
+        </style>
+        <DInputCurrency
+          {...args}
+          value={innerValue}
+          onChange={(newValue) => {
+            setInnerValue(newValue);
+            if (args.onChange) {
+              args.onChange(newValue);
+            }
+          }}
+        />
+      </DContextProvider>
+    );
   },
 };

--- a/stories/components/DInputCurrency.stories.tsx
+++ b/stories/components/DInputCurrency.stories.tsx
@@ -6,6 +6,29 @@ import { ICONS } from '../config/constants';
 import { DContextProvider } from '../../src';
 import { PREFIX_BS } from '../../src/components/config';
 
+function renderWithState(cssText?: string) {
+  return function Render(args: ComponentProps<typeof DInputCurrency>) {
+    const { value, onChange, ...restArgs } = args;
+    const [innerValue, setInnerValue] = useState<number | undefined>(value);
+
+    return (
+      <DContextProvider>
+        {cssText && <style>{cssText}</style>}
+        <DInputCurrency
+          {...restArgs}
+          value={innerValue}
+          onChange={(newValue) => {
+            setInnerValue(newValue);
+            if (onChange) {
+              onChange(newValue);
+            }
+          }}
+        />
+      </DContextProvider>
+    );
+  };
+}
+
 const config: Meta<typeof DInputCurrency> = {
   title: 'Design System/Components/Input Currency',
   component: DInputCurrency,
@@ -40,7 +63,7 @@ and so it does [Input Group CSS Variables](https://getbootstrap.com/docs/5.3/for
 | --${PREFIX_BS}form-text-gap               | .form-text    | css length unit | Space between hint elements  |
 | --${PREFIX_BS}form-text-color             | .form-text    | css color unit  | Hint color                   |
 | --${PREFIX_BS}form-control-text-align     | .form-control | css text align  | Input text align             |
-| --${PREFIX_BS}input-currency-symbol-color | .input-group  | css color unit  | Color of the currency symbol |
+| --${PREFIX_BS}input-currency-component-symbol-color | .d-input-currency-symbol | css color unit | Color of the currency symbol (set via class or style) |
 | --${PREFIX_BS}icon-component-color        | .d-icon       | css color unit  | Color of the \`iconStart\`/\`iconEnd\` icon |
 
 ## Changing the currency symbol color
@@ -250,24 +273,7 @@ regular \`className\`:
     },
   },
   tags: ['autodocs'],
-  render: function Render(args: ComponentProps<typeof DInputCurrency>) {
-    const [innerValue, setInnerValue] = useState<number | undefined>(args.value);
-
-    return (
-      <DContextProvider>
-        <DInputCurrency
-          {...args}
-          value={innerValue}
-          onChange={(newValue) => {
-            setInnerValue(newValue);
-            if (args.onChange) {
-              args.onChange(newValue);
-            }
-          }}
-        />
-      </DContextProvider>
-    );
-  },
+  render: renderWithState(),
 };
 
 export default config;
@@ -384,31 +390,11 @@ Changes the color of the \`iconEnd\` icon using \`className\` to scope the
       },
     },
   },
-  render: function Render(args: ComponentProps<typeof DInputCurrency>) {
-    const [innerValue, setInnerValue] = useState<number | undefined>(args.value);
-
-    return (
-      <DContextProvider>
-        <style>
-          {`
-            .d-input-currency-icon-color-demo .d-icon {
-              --${PREFIX_BS}icon-component-color: #dc3545;
-            }
-          `}
-        </style>
-        <DInputCurrency
-          {...args}
-          value={innerValue}
-          onChange={(newValue) => {
-            setInnerValue(newValue);
-            if (args.onChange) {
-              args.onChange(newValue);
-            }
-          }}
-        />
-      </DContextProvider>
-    );
-  },
+  render: renderWithState(`
+    .d-input-currency-icon-color-demo .d-icon {
+      --${PREFIX_BS}icon-component-color: #dc3545;
+    }
+  `),
 };
 
 export const WithSymbolColor: Story = {
@@ -437,29 +423,9 @@ Changes the currency symbol color using \`className\` to scope the
       },
     },
   },
-  render: function Render(args: ComponentProps<typeof DInputCurrency>) {
-    const [innerValue, setInnerValue] = useState<number | undefined>(args.value);
-
-    return (
-      <DContextProvider>
-        <style>
-          {`
-            .d-input-currency-symbol-color-demo {
-              --${PREFIX_BS}input-currency-component-symbol-color: #dc3545;
-            }
-          `}
-        </style>
-        <DInputCurrency
-          {...args}
-          value={innerValue}
-          onChange={(newValue) => {
-            setInnerValue(newValue);
-            if (args.onChange) {
-              args.onChange(newValue);
-            }
-          }}
-        />
-      </DContextProvider>
-    );
-  },
+  render: renderWithState(`
+    .d-input-currency-symbol-color-demo {
+      --${PREFIX_BS}input-currency-component-symbol-color: #dc3545;
+    }
+  `),
 };


### PR DESCRIPTION
## Problema

Ver #1139.

El color del símbolo de moneda (`$`, `CLP`, etc.) de `DInputCurrency` se definía mediante variables CSS aplicadas como `style` inline sobre el elemento raíz del componente. Esto generaba dos problemas:

1. **El prop `style` reemplazaba (no combinaba) el estilo interno.** En `DInputCurrency.tsx`, `{...props}` se spreadea después del `style` explícito, por lo que si el consumidor pasaba su propio `style`, sobrescribía por completo el `style={generateStyleVariables}` interno generado por `useInputCurrency`, perdiendo el color del símbolo.
2. **Tampoco era posible sobrescribir el color desde una clase CSS externa.** Al estar la variable definida vía `style` inline en el elemento raíz, una clase CSS apuntando a ese mismo elemento nunca podía ganarle — un `style` inline siempre tiene mayor prioridad que cualquier regla de hoja de estilos sobre el mismo elemento, sin importar su especificidad.

## Solución

Se movió la definición del color del símbolo desde `style` inline (generado en React vía `useInputCurrency`) a una **clase CSS real** en SCSS, siguiendo el mismo patrón que ya usa `.d-icon` (`--bs-icon-component-color` → `--bs-icon-color`):

- Nuevo `src/style/abstracts/variables/_input-currency.scss`: variable Sass `$input-currency-symbol-color` con default `var(--bs-secondary)`.
- Nuevo `src/style/components/_d-input-currency.scss`: clase `.d-input-currency-symbol` que define:
  ```scss
  .d-input-currency-symbol {
    --bs-input-currency-symbol-color: var(--bs-input-currency-component-symbol-color, #{$input-currency-symbol-color});
    color: var(--bs-input-currency-symbol-color);
  }
  ```
  La variable `--bs-input-currency-component-symbol-color` actúa como "API pública": puede sobrescribirse desde cualquier ancestro (`className` o el propio `style` del componente) sin necesidad de conocer la estructura interna, porque ya no compite con una declaración `style` inline en el mismo elemento.
- Ambos partials registrados en sus respectivos `_+import.scss`.
- `DInputCurrency.tsx`: el `<span>` del símbolo ahora usa `className="d-input-currency-symbol"` en lugar de `style`; `<DInput>` ya no recibe ningún `style` interno, por lo que el `style` del consumidor pasa intacto.
- `useInputCurrency.ts`: se eliminan `generateStyleVariables` y `generateSymbolStyleVariables`, ya innecesarios.
- Tests y snapshot actualizados acorde al nuevo markup/clases.
- Storybook: se documenta cómo cambiar el color del símbolo (`--bs-input-currency-component-symbol-color`) y del icono `iconStart`/`iconEnd` (`--bs-icon-component-color`), con stories `WithSymbolColor` y `WithIconColor`.

## Validación
- `tsc --noEmit`: sin errores.
- `eslint`: sin errores.
- Compilación real de Sass (`sass --load-path=.`): el CSS generado coincide con lo esperado.
- Jest: 23 test suites / 179 tests pasando (incluye `DInputCurrency`, `useInputCurrency`, `DInput`, `DInputPhone`).
- Verificado en Storybook (stories indexadas y renderizando correctamente) y con una prueba real en navegador (Playwright) confirmando el comportamiento de cascada de custom properties CSS que motivó este fix.

Fixes #1139