### PR TITLE
feat(hooks): add useOtp headless hook and export useCountdown

### DIFF
--- a/src/components/DOtp/DOtp.spec.tsx
+++ b/src/components/DOtp/DOtp.spec.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DOtp from './DOtp';
+
+describe('DOtp', () => {
+  it('should render title, pin input and submit button', () => {
+    render(<DOtp action={() => {}} />);
+
+    expect(screen.getByText(
+      'We will send you a 6-digit code to your associated phone number so you can continue with your request.',
+    )).toBeInTheDocument();
+    expect(screen.getAllByRole('textbox')).toHaveLength(6);
+    expect(screen.getByText('Authorize and continue')).toBeInTheDocument();
+  });
+
+  it('should call action when a complete otp is submitted', async () => {
+    const user = userEvent.setup();
+    const action = jest.fn();
+    render(<DOtp action={action} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '123456');
+    await user.click(screen.getByText('Authorize and continue'));
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show the invalid state and not call action when otp is too short', async () => {
+    const user = userEvent.setup();
+    const action = jest.fn();
+    render(<DOtp action={action} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '123');
+    await user.click(screen.getByText('Authorize and continue'));
+
+    expect(action).not.toHaveBeenCalled();
+    expect(inputs[0]).toHaveClass('is-invalid');
+    expect(screen.getByText('Invalid code, please try again.')).toBeInTheDocument();
+  });
+
+  // Regression test: DInputPin (uncontrolled) can re-notify onChange with
+  // the same otp string across renders even without a new keystroke. This
+  // must not clear an `invalid` state that a previous submit() just set.
+  it('should keep showing the invalid state after a submit, even if DInputPin re-fires onChange', async () => {
+    const user = userEvent.setup();
+    const action = jest.fn();
+    render(<DOtp action={action} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '123');
+    await user.click(screen.getByText('Authorize and continue'));
+
+    // Give any pending effects (like DInputPin's onChange notification
+    // effect) a chance to run before asserting the invalid state persists.
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+    expect(inputs[0]).toHaveClass('is-invalid');
+    expect(screen.getByText('Invalid code, please try again.')).toBeInTheDocument();
+  });
+});

--- a/src/components/DOtp/DOtp.spec.tsx
+++ b/src/components/DOtp/DOtp.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DOtp from './DOtp';
 
@@ -37,6 +37,27 @@ describe('DOtp', () => {
     expect(action).not.toHaveBeenCalled();
     expect(inputs[0]).toHaveClass('is-invalid');
     expect(screen.getByText('Invalid code, please try again.')).toBeInTheDocument();
+  });
+
+  it('should show the submit button as loading while action is pending, using the hook\'s internal isLoading', async () => {
+    const user = userEvent.setup();
+    let resolveAction: () => void = () => {};
+    const action = jest.fn(() => new Promise<void>((resolve) => {
+      resolveAction = resolve;
+    }));
+    render(<DOtp action={action} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '123456');
+    await user.click(screen.getByText('Authorize and continue'));
+
+    const button = screen.getByRole('button', { name: 'Authorize and continue' });
+    expect(button).toHaveAttribute('aria-busy', 'true');
+
+    resolveAction();
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-busy', 'false');
+    });
   });
 
   // Regression test: DInputPin (uncontrolled) can re-notify onChange with

--- a/src/components/DOtp/DOtp.tsx
+++ b/src/components/DOtp/DOtp.tsx
@@ -23,7 +23,7 @@ export type PropsOtp = PropsWithChildren<{
 
 const TEXT_PROPS = {
   resend: 'Resend',
-  resendText: 'Resend code',
+  resendText: 'Resend',
   submit: 'Authorize and continue',
   title: 'We will send you a 6-digit code to your associated phone number so you can continue with your request.',
   invalidCode: 'Invalid code, please try again.',
@@ -77,7 +77,7 @@ export default function DOtp(
           <OtpCountdown
             secondsLeft={secondsLeft}
             restartCountdown={restartCountdown}
-            resendText={texts.resend}
+            resendText={texts.resendText}
           />
         </div>
         <hr className="m-0" />

--- a/src/components/DOtp/DOtp.tsx
+++ b/src/components/DOtp/DOtp.tsx
@@ -57,6 +57,7 @@ export default function DOtp(
     setOtp,
     invalid,
     submit,
+    isLoading: isSubmitting,
     secondsLeft,
     restartCountdown,
   } = useOtp({ action, otpSize, seconds });
@@ -90,7 +91,7 @@ export default function DOtp(
                 console.error('Error in DOtp action:', err);
               });
             }}
-            loading={isLoading}
+            loading={isLoading || isSubmitting}
           />
           <p className="small ms-lg-auto mb-0">
             {texts.contact}

--- a/src/components/DOtp/DOtp.tsx
+++ b/src/components/DOtp/DOtp.tsx
@@ -1,12 +1,9 @@
-import {
-  PropsWithChildren,
-  useCallback,
-  useState,
-} from 'react';
+import { PropsWithChildren } from 'react';
 
 import OtpCountdown from './components/OtpCountdown';
 import DInputPin from '../DInputPin';
 import DButton from '../DButton';
+import useOtp from '../../hooks/useOtp';
 
 export type PropsOtp = PropsWithChildren<{
   action: () => Promise<void> | void;
@@ -20,6 +17,7 @@ export type PropsOtp = PropsWithChildren<{
     title?: string;
     contact?: string | React.ReactNode;
     resendText?: string;
+    invalidCode?: string;
   }
 }>;
 
@@ -28,6 +26,7 @@ const TEXT_PROPS = {
   resendText: 'Resend code',
   submit: 'Authorize and continue',
   title: 'We will send you a 6-digit code to your associated phone number so you can continue with your request.',
+  invalidCode: 'Invalid code, please try again.',
   contact: (
     <>
       <span>Problems with your digital token? Contact us</span>
@@ -54,23 +53,13 @@ export default function DOtp(
     seconds = 15,
   }: PropsOtp,
 ) {
-  const [otp, setOtp] = useState('');
-  const [invalid, setInvalid] = useState(false);
-
-  const handler = useCallback(async () => {
-    if (otp.length < otpSize) {
-      setInvalid(true);
-      return;
-    }
-
-    setInvalid(false);
-
-    await action();
-  }, [
-    otp.length,
-    action,
-    otpSize,
-  ]);
+  const {
+    setOtp,
+    invalid,
+    submit,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({ action, otpSize, seconds });
 
   return (
     <div className={className}>
@@ -81,11 +70,13 @@ export default function DOtp(
             className="modal-otp-pin"
             characters={otpSize}
             onChange={(e) => setOtp(e)}
-            invalid={invalid && otp.length < otpSize}
+            invalid={invalid}
+            hint={invalid ? texts.invalidCode : undefined}
             placeholder="0"
           />
           <OtpCountdown
-            seconds={seconds}
+            secondsLeft={secondsLeft}
+            restartCountdown={restartCountdown}
             resendText={texts.resend}
           />
         </div>
@@ -94,7 +85,7 @@ export default function DOtp(
           <DButton
             text={texts.submit}
             onClick={() => {
-              handler().catch((err) => {
+              submit().catch((err) => {
                 // eslint-disable-next-line no-console
                 console.error('Error in DOtp action:', err);
               });

--- a/src/components/DOtp/components/OtpCountdown.tsx
+++ b/src/components/DOtp/components/OtpCountdown.tsx
@@ -1,8 +1,8 @@
-import useCountdown from '../hooks/useCountdown';
 import DButton from '../../DButton';
 
 type Props = {
-  seconds: number;
+  secondsLeft: number;
+  restartCountdown: () => void;
   resendText?: string;
   message?: (secondsLeft: number) => string;
 };
@@ -15,13 +15,12 @@ const defaultMessage = (secs: number) => (
 
 export default function OtpCountdown(
   {
-    seconds,
+    secondsLeft,
+    restartCountdown,
     resendText,
     message,
   }: Props,
 ) {
-  const { secondsLeft, restartCountdown } = useCountdown(seconds);
-
   return (
     <div className="d-flex gap-2 align-items-center">
       <p className="mb-0 flex-1">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,3 +21,6 @@ export {
   useMediaBreakpointUpXl,
   useMediaBreakpointUpXxl,
 } from './useMediaBreakpointUp';
+export { default as useCountdown } from './useCountdown';
+export { default as useOtp } from './useOtp';
+export type { UseOtpConfig, UseOtpReturn } from './useOtp';

--- a/src/hooks/tests/useCountdown.spec.ts
+++ b/src/hooks/tests/useCountdown.spec.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+import useCountdown from '../useCountdown';
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should start with the given seconds', () => {
+    const { result } = renderHook(() => useCountdown(5));
+    expect(result.current.secondsLeft).toBe(5);
+  });
+
+  it('should count down every second until it reaches 0', () => {
+    const { result } = renderHook(() => useCountdown(3));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(2);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(0);
+  });
+
+  it('should not go below 0 once finished', () => {
+    const { result } = renderHook(() => useCountdown(1));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(0);
+  });
+
+  it('should restart the countdown back to the initial seconds', () => {
+    const { result } = renderHook(() => useCountdown(2));
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.secondsLeft).toBe(0);
+
+    act(() => {
+      result.current.restartCountdown();
+    });
+    expect(result.current.secondsLeft).toBe(2);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(1);
+  });
+});

--- a/src/hooks/tests/useOtp.spec.tsx
+++ b/src/hooks/tests/useOtp.spec.tsx
@@ -92,6 +92,35 @@ describe('useOtp', () => {
     expect(result.current.error).toBe(null);
   });
 
+  it('should NOT clear invalid/error when setOtp is called again with the same value (no-op)', async () => {
+    // Regression test: an uncontrolled pin input (like DInputPin) may
+    // re-notify the same otp string (e.g. its onChange callback identity
+    // changed on the parent's re-render) without any real user edit. That
+    // must not wipe out an `invalid`/`error` state set by a previous
+    // submit() call.
+    const rejectionError = new Error('Wrong OTP code');
+    const action = jest.fn().mockRejectedValue(rejectionError);
+    const { result, rerender } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+    rerender();
+
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+    expect(result.current.invalid).toBe(true);
+    expect(result.current.error).toBe(rejectionError);
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+
+    expect(result.current.invalid).toBe(true);
+    expect(result.current.error).toBe(rejectionError);
+  });
+
   it('should expose a working countdown/restart pair', () => {
     const action = jest.fn();
     const { result } = renderHook(() => useOtp({ action, seconds: 2 }));

--- a/src/hooks/tests/useOtp.spec.tsx
+++ b/src/hooks/tests/useOtp.spec.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import useOtp from '../useOtp';
+
+describe('useOtp', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should initialize with empty otp, not invalid, and full countdown', () => {
+    const action = jest.fn();
+    const { result } = renderHook(() => useOtp({ action, otpSize: 6, seconds: 15 }));
+
+    expect(result.current.otp).toBe('');
+    expect(result.current.invalid).toBe(false);
+    expect(result.current.secondsLeft).toBe(15);
+  });
+
+  it('should mark invalid and not call action when otp is shorter than otpSize', async () => {
+    const action = jest.fn();
+    const { result } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123');
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(result.current.invalid).toBe(true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('should clear invalid and call action when otp reaches otpSize', async () => {
+    const action = jest.fn();
+    const { result, rerender } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(result.current.invalid).toBe(false);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mark invalid and expose the error when action rejects (wrong code)', async () => {
+    const rejectionError = new Error('Wrong OTP code');
+    const action = jest.fn().mockRejectedValue(rejectionError);
+    const { result, rerender } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+    rerender();
+
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow('Wrong OTP code');
+    });
+
+    expect(result.current.invalid).toBe(true);
+    expect(result.current.error).toBe(rejectionError);
+  });
+
+  it('should clear invalid/error as soon as the otp is edited again', async () => {
+    const action = jest.fn().mockRejectedValue(new Error('Wrong OTP code'));
+    const { result, rerender } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+    rerender();
+
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+    expect(result.current.invalid).toBe(true);
+
+    act(() => {
+      result.current.setOtp('654321');
+    });
+
+    expect(result.current.invalid).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('should expose a working countdown/restart pair', () => {
+    const action = jest.fn();
+    const { result } = renderHook(() => useOtp({ action, seconds: 2 }));
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.secondsLeft).toBe(0);
+
+    act(() => {
+      result.current.restartCountdown();
+    });
+    expect(result.current.secondsLeft).toBe(2);
+  });
+});

--- a/src/hooks/tests/useOtp.spec.tsx
+++ b/src/hooks/tests/useOtp.spec.tsx
@@ -16,6 +16,7 @@ describe('useOtp', () => {
 
     expect(result.current.otp).toBe('');
     expect(result.current.invalid).toBe(false);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.secondsLeft).toBe(15);
   });
 
@@ -134,5 +135,64 @@ describe('useOtp', () => {
       result.current.restartCountdown();
     });
     expect(result.current.secondsLeft).toBe(2);
+  });
+
+  it('should set isLoading to true while action is pending and back to false once it resolves', async () => {
+    let resolveAction: () => void = () => {};
+    const action = jest.fn(() => new Promise<void>((resolve) => {
+      resolveAction = resolve;
+    }));
+    const { result, rerender } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+    rerender();
+
+    let submitPromise: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolveAction();
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should set isLoading back to false when action rejects', async () => {
+    const action = jest.fn().mockRejectedValue(new Error('Wrong OTP code'));
+    const { result, rerender } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123456');
+    });
+    rerender();
+
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should NOT set isLoading when otp is shorter than otpSize (action is never called)', async () => {
+    const action = jest.fn();
+    const { result } = renderHook(() => useOtp({ action, otpSize: 6 }));
+
+    act(() => {
+      result.current.setOtp('123');
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(action).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useCountdown.tsx
+++ b/src/hooks/useCountdown.tsx
@@ -4,6 +4,16 @@ import {
   useCallback,
 } from 'react';
 
+/**
+ * Generic seconds-based countdown hook.
+ *
+ * Starts counting down from `seconds` to `0` and exposes `restartCountdown`
+ * to reset and restart the timer (e.g. for "resend code in Xs" patterns,
+ * session-expiry banners, or any other cooldown/throttle UI).
+ *
+ * @example
+ * const { secondsLeft, restartCountdown } = useCountdown(30);
+ */
 export default function useCountdown(seconds: number) {
   const [secondsLeft, setSecondsLeft] = useState(seconds);
   const [isActive, setIsActive] = useState(true);

--- a/src/hooks/useOtp.tsx
+++ b/src/hooks/useOtp.tsx
@@ -15,8 +15,10 @@ export type UseOtpReturn = {
   otp: string;
   /**
    * Updates the OTP value (wire this to your custom pin input's `onChange`).
-   * Also clears `invalid`/`error` so the error state disappears as soon as
-   * the user edits the code.
+   * Also clears `invalid`/`error` as soon as the value actually changes, so
+   * the error state disappears once the user edits the code (a no-op call
+   * with the same value, e.g. from an uncontrolled input re-notifying its
+   * current value, does not reset `invalid`/`error`).
    */
   setOtp: (value: string) => void;
   /**
@@ -99,9 +101,18 @@ export default function useOtp(
   const { secondsLeft, restartCountdown } = useCountdown(seconds);
 
   const setOtp = useCallback((value: string) => {
-    setInvalid(false);
-    setError(null);
-    setOtpValue(value);
+    setOtpValue((prevOtp) => {
+      // Guard against no-op calls (e.g. DInputPin re-notifying the same
+      // value when its onChange reference changes) so we don't wipe out
+      // an `invalid`/`error` state that was just set by submit().
+      if (prevOtp === value) {
+        return prevOtp;
+      }
+
+      setInvalid(false);
+      setError(null);
+      return value;
+    });
   }, []);
 
   const submit = useCallback(async () => {

--- a/src/hooks/useOtp.tsx
+++ b/src/hooks/useOtp.tsx
@@ -39,6 +39,15 @@ export type UseOtpReturn = {
    * `.catch()` it for logging), and `invalid`/`error` are set beforehand.
    */
   submit: () => Promise<void>;
+  /**
+   * `true` while `action` is being awaited inside `submit()` (i.e. the OTP
+   * passed the length check and the async action hasn't settled yet). Wire
+   * it to your submit button's loading/disabled state. It's `false` while
+   * idle and immediately after `action` settles (whether it resolves or
+   * rejects), and it's never set to `true` for the too-short/length
+   * validation failure since `action` isn't called in that case.
+   */
+  isLoading: boolean;
   /** Seconds remaining until resend is available. */
   secondsLeft: number;
   /** Restarts the resend countdown (call it from your "Resend" action). */
@@ -72,6 +81,7 @@ export type UseOtpReturn = {
  *     invalid,
  *     error,
  *     submit,
+ *     isLoading,
  *     secondsLeft,
  *     restartCountdown,
  *   } = useOtp({ action: async () => verifyOtp(otp), otpSize: 6, seconds: 15 });
@@ -80,7 +90,9 @@ export type UseOtpReturn = {
  *     <>
  *       <MyCustomPinInput value={otp} onChange={setOtp} invalid={invalid} />
  *       {invalid && <span>{error ? 'Invalid code' : 'Enter all digits'}</span>}
- *       <button onClick={() => { submit().catch(() => {}); }}>Submit</button>
+ *       <button disabled={isLoading} onClick={() => { submit().catch(() => {}); }}>
+ *         {isLoading ? 'Submitting...' : 'Submit'}
+ *       </button>
  *       <button disabled={secondsLeft > 0} onClick={restartCountdown}>
  *         Resend {secondsLeft > 0 ? `(${secondsLeft}s)` : ''}
  *       </button>
@@ -98,6 +110,7 @@ export default function useOtp(
   const [otp, setOtpValue] = useState('');
   const [invalid, setInvalid] = useState(false);
   const [error, setError] = useState<unknown>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const { secondsLeft, restartCountdown } = useCountdown(seconds);
 
   const setOtp = useCallback((value: string) => {
@@ -122,6 +135,7 @@ export default function useOtp(
       return;
     }
 
+    setIsLoading(true);
     try {
       await action();
       setInvalid(false);
@@ -130,6 +144,8 @@ export default function useOtp(
       setInvalid(true);
       setError(err);
       throw err;
+    } finally {
+      setIsLoading(false);
     }
   }, [
     otp.length,
@@ -143,6 +159,7 @@ export default function useOtp(
     invalid,
     error,
     submit,
+    isLoading,
     secondsLeft,
     restartCountdown,
   };

--- a/src/hooks/useOtp.tsx
+++ b/src/hooks/useOtp.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useState } from 'react';
+import useCountdown from './useCountdown';
+
+export type UseOtpConfig = {
+  /** Called when the OTP reaches the expected length and `submit()` is invoked. */
+  action: () => Promise<void> | void;
+  /** Expected number of digits/characters for a valid OTP. Defaults to `6`. */
+  otpSize?: number;
+  /** Initial countdown (in seconds) before resend becomes available. Defaults to `15`. */
+  seconds?: number;
+};
+
+export type UseOtpReturn = {
+  /** Current OTP value. */
+  otp: string;
+  /**
+   * Updates the OTP value (wire this to your custom pin input's `onChange`).
+   * Also clears `invalid`/`error` so the error state disappears as soon as
+   * the user edits the code.
+   */
+  setOtp: (value: string) => void;
+  /**
+   * `true` when `submit()` is called with an OTP shorter than `otpSize`, or
+   * when `action` throws/rejects (e.g. the backend rejected the digited
+   * code as incorrect).
+   */
+  invalid: boolean;
+  /**
+   * The value thrown/rejected by `action`, or `null` otherwise. Use it to
+   * render a specific message for a wrong code, as opposed to a too-short
+   * one.
+   */
+  error: unknown;
+  /**
+   * Validates the OTP length; if valid, calls `action`. If `action`
+   * rejects, the returned promise rejects too (so callers can still
+   * `.catch()` it for logging), and `invalid`/`error` are set beforehand.
+   */
+  submit: () => Promise<void>;
+  /** Seconds remaining until resend is available. */
+  secondsLeft: number;
+  /** Restarts the resend countdown (call it from your "Resend" action). */
+  restartCountdown: () => void;
+};
+
+/**
+ * Headless hook exposing the same OTP logic used internally by `DOtp`
+ * (code state, length + correctness validation, submit action and resend
+ * countdown), without any bundled markup/styles.
+ *
+ * Use this when the default `DOtp` component doesn't match your design and
+ * you need to build a fully custom UI while reusing the same behavior.
+ *
+ * Internally composes `useCountdown` for the resend timer and re-exposes
+ * `secondsLeft`/`restartCountdown`, so there is no need to call
+ * `useCountdown` separately.
+ *
+ * `invalid` becomes `true` both when the OTP is shorter than `otpSize` and
+ * when `action` throws/rejects (e.g. the backend rejected the digited code
+ * as incorrect). In the latter case, the thrown value is exposed as `error`
+ * so custom UIs can render an appropriate message (e.g. "Invalid code" vs.
+ * "Enter all digits"). `invalid`/`error` are cleared automatically as soon
+ * as the user edits the code via `setOtp`.
+ *
+ * @example
+ * function CustomOtp() {
+ *   const {
+ *     otp,
+ *     setOtp,
+ *     invalid,
+ *     error,
+ *     submit,
+ *     secondsLeft,
+ *     restartCountdown,
+ *   } = useOtp({ action: async () => verifyOtp(otp), otpSize: 6, seconds: 15 });
+ *
+ *   return (
+ *     <>
+ *       <MyCustomPinInput value={otp} onChange={setOtp} invalid={invalid} />
+ *       {invalid && <span>{error ? 'Invalid code' : 'Enter all digits'}</span>}
+ *       <button onClick={() => { submit().catch(() => {}); }}>Submit</button>
+ *       <button disabled={secondsLeft > 0} onClick={restartCountdown}>
+ *         Resend {secondsLeft > 0 ? `(${secondsLeft}s)` : ''}
+ *       </button>
+ *     </>
+ *   );
+ * }
+ */
+export default function useOtp(
+  {
+    action,
+    otpSize = 6,
+    seconds = 15,
+  }: UseOtpConfig,
+): UseOtpReturn {
+  const [otp, setOtpValue] = useState('');
+  const [invalid, setInvalid] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const { secondsLeft, restartCountdown } = useCountdown(seconds);
+
+  const setOtp = useCallback((value: string) => {
+    setInvalid(false);
+    setError(null);
+    setOtpValue(value);
+  }, []);
+
+  const submit = useCallback(async () => {
+    if (otp.length < otpSize) {
+      setInvalid(true);
+      setError(null);
+      return;
+    }
+
+    try {
+      await action();
+      setInvalid(false);
+      setError(null);
+    } catch (err) {
+      setInvalid(true);
+      setError(err);
+      throw err;
+    }
+  }, [
+    otp.length,
+    action,
+    otpSize,
+  ]);
+
+  return {
+    otp,
+    setOtp,
+    invalid,
+    error,
+    submit,
+    secondsLeft,
+    restartCountdown,
+  };
+}

--- a/src/hooks/useOtp.tsx
+++ b/src/hooks/useOtp.tsx
@@ -23,7 +23,7 @@ export type UseOtpReturn = {
   setOtp: (value: string) => void;
   /**
    * `true` when `submit()` is called with an OTP shorter than `otpSize`, or
-   * when `action` throws/rejects (e.g. the backend rejected the digited
+   * when `action` throws/rejects (e.g. the backend rejected the entered
    * code as incorrect).
    */
   invalid: boolean;
@@ -58,7 +58,7 @@ export type UseOtpReturn = {
  * `useCountdown` separately.
  *
  * `invalid` becomes `true` both when the OTP is shorter than `otpSize` and
- * when `action` throws/rejects (e.g. the backend rejected the digited code
+ * when `action` throws/rejects (e.g. the backend rejected the entered code
  * as incorrect). In the latter case, the thrown value is exposed as `error`
  * so custom UIs can render an appropriate message (e.g. "Invalid code" vs.
  * "Enter all digits"). `invalid`/`error` are cleared automatically as soon

--- a/stories/hooks/useCountdown.mdx
+++ b/stories/hooks/useCountdown.mdx
@@ -1,0 +1,63 @@
+import { Meta, Unstyled, Source } from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './useCountdownExamples';
+
+<Meta title="Design System/Hooks/useCountdown" />
+
+# useCountdown
+
+Generic seconds-based countdown hook. Starts counting down from `seconds` to
+`0` and exposes `restartCountdown` to reset and restart the timer.
+
+Useful for any cooldown/throttle UI: "resend code in Xs" patterns, session-
+expiry banners, rate-limited actions, etc. It is used internally by
+[`useOtp`](?path=/docs/design-system-hooks-useotp--docs) to power the resend
+countdown, but it is fully generic and framework-agnostic beyond that.
+
+## Parameters
+
+- **seconds**: `number` — the number of seconds the countdown starts from.
+
+## Return Values
+
+- **secondsLeft**: `number` — seconds remaining until the countdown reaches `0`.
+- **restartCountdown**: `() => void` — resets `secondsLeft` back to `seconds`
+  and restarts the timer.
+
+## Example of use `ExampleOfUse.tsx`
+
+<Source
+  code={
+    `
+import { useCountdown, DButton, DCard } from '@dynamic-framework/ui-react';
+
+export function ExampleOfUse() {
+  const { secondsLeft, restartCountdown } = useCountdown(10);
+
+  return (
+    <DCard>
+      <DCard.Body className="d-flex align-items-center gap-3">
+        <p className="mb-0">
+          {secondsLeft > 0 ? \`Resend available in \${secondsLeft}s\` : 'You can resend now'}
+        </p>
+        <DButton
+          size="sm"
+          variant="link"
+          text="Resend"
+          disabled={secondsLeft > 0}
+          onClick={restartCountdown}
+        />
+      </DCard.Body>
+    </DCard>
+  );
+}
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/hooks/useCountdownExamples.tsx
+++ b/stories/hooks/useCountdownExamples.tsx
@@ -1,0 +1,30 @@
+import {
+  useCountdown,
+  DButton,
+  DCard,
+} from '../../src';
+
+export function ExampleOfUse() {
+  const { secondsLeft, restartCountdown } = useCountdown(10);
+
+  return (
+    <DCard>
+      <DCard.Body className="d-flex align-items-center gap-3">
+        <p className="mb-0">
+          {secondsLeft > 0 ? `Resend available in ${secondsLeft}s` : 'You can resend now'}
+        </p>
+        <DButton
+          size="sm"
+          variant="link"
+          text="Resend"
+          disabled={secondsLeft > 0}
+          onClick={restartCountdown}
+        />
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}

--- a/stories/hooks/useOtp.mdx
+++ b/stories/hooks/useOtp.mdx
@@ -1,0 +1,107 @@
+import { Meta, Unstyled, Source } from '@storybook/addon-docs/blocks';
+import { ExampleRoot } from './useOtpExamples';
+
+<Meta title="Design System/Hooks/useOtp" />
+
+# useOtp
+
+Headless hook exposing the same One-Time Password (OTP) logic used internally
+by [`DOtp`](?path=/docs/design-system-components-otp--docs) — code state,
+length validation, submit action and resend countdown — **without any bundled
+markup or styles**.
+
+Use `useOtp` when the default `DOtp` component doesn't match your design and
+you need to build a fully custom UI (different layout, custom pin input,
+alerts, etc.) while reusing the exact same behavior.
+
+Internally it composes [`useCountdown`](?path=/docs/design-system-hooks-usecountdown--docs)
+for the resend timer and re-exposes `secondsLeft`/`restartCountdown`, so there
+is no need to call `useCountdown` separately.
+
+## Parameters
+
+### `UseOtpConfig`
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `action` | `() => Promise<void> \| void` | ✅ | | Called when the OTP reaches the expected length and `submit()` is invoked. |
+| `otpSize` | `number` | | `6` | Expected number of digits/characters for a valid OTP. |
+| `seconds` | `number` | | `15` | Initial countdown (in seconds) before resend becomes available. |
+
+## Return Values
+
+- **otp**: `string` — current OTP value.
+- **setOtp**: `(value: string) => void` — updates the OTP value (wire this to
+  your custom pin input's `onChange`). Also clears `invalid`/`error` so the
+  error state disappears as soon as the user edits the code.
+- **invalid**: `boolean` — `true` when `submit()` is called with an OTP
+  shorter than `otpSize`, **or** when `action` throws/rejects (e.g. the
+  backend rejected the digited code as incorrect).
+- **error**: `unknown` — the value thrown/rejected by `action`, `null`
+  otherwise. Use it to render a specific message for a wrong code, as opposed
+  to a too-short one.
+- **submit**: `() => Promise<void>` — validates the OTP length; if valid,
+  calls `action`. If `action` rejects, `submit()`'s promise rejects too (so
+  callers can still `.catch()` it for logging), and `invalid`/`error` are set.
+- **secondsLeft**: `number` — seconds remaining until resend is available.
+- **restartCountdown**: `() => void` — restarts the resend countdown (call it
+  from your "Resend" action).
+
+## Example of use `ExampleOfUse.tsx`
+
+<Source
+  code={
+    `
+import { useOtp, DInputPin, DButton, DAlert } from '@dynamic-framework/ui-react';
+
+export function ExampleOfUse() {
+  const {
+    otp, setOtp, invalid, error, submit, secondsLeft, restartCountdown,
+  } = useOtp({
+    // Simulates a backend call that rejects any code other than "1234".
+    action: () => new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (otp === '1234') {
+          resolve();
+        } else {
+          reject(new Error('The code you entered is incorrect.'));
+        }
+      }, 800);
+    }),
+    otpSize: 4,
+    seconds: 10,
+  });
+
+  return (
+    <div className="d-flex flex-column gap-3" style={{ maxWidth: 360 }}>
+      <h5 className="mb-0">Enter your verification code</h5>
+      <DInputPin characters={4} onChange={setOtp} invalid={invalid} placeholder="•" />
+      {invalid && (
+        <DAlert color="danger">
+          {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+        </DAlert>
+      )}
+      <div className="d-flex justify-content-between align-items-center">
+        <DButton
+          variant="link"
+          size="sm"
+          text={secondsLeft > 0 ? \`Resend in \${secondsLeft}s\` : 'Resend code'}
+          disabled={secondsLeft > 0}
+          onClick={restartCountdown}
+        />
+        <DButton text="Verify" onClick={() => { submit().catch(() => {}); }} />
+      </div>
+    </div>
+  );
+}
+`
+  }
+  language="tsx"
+  dark
+/>
+
+## Example Render
+
+<Unstyled>
+  <ExampleRoot />
+</Unstyled>

--- a/stories/hooks/useOtp.mdx
+++ b/stories/hooks/useOtp.mdx
@@ -32,11 +32,12 @@ is no need to call `useCountdown` separately.
 
 - **otp**: `string` — current OTP value.
 - **setOtp**: `(value: string) => void` — updates the OTP value (wire this to
-  your custom pin input's `onChange`). Also clears `invalid`/`error` so the
-  error state disappears as soon as the user edits the code.
+  your custom pin input's `onChange`). Clears `invalid`/`error` as soon as
+  the value actually changes, so the error state disappears once the user
+  edits the code (a no-op call with the same value does not reset it).
 - **invalid**: `boolean` — `true` when `submit()` is called with an OTP
   shorter than `otpSize`, **or** when `action` throws/rejects (e.g. the
-  backend rejected the digited code as incorrect).
+  backend rejected the entered code as incorrect).
 - **error**: `unknown` — the value thrown/rejected by `action`, `null`
   otherwise. Use it to render a specific message for a wrong code, as opposed
   to a too-short one.

--- a/stories/hooks/useOtp.mdx
+++ b/stories/hooks/useOtp.mdx
@@ -44,6 +44,10 @@ is no need to call `useCountdown` separately.
 - **submit**: `() => Promise<void>` — validates the OTP length; if valid,
   calls `action`. If `action` rejects, `submit()`'s promise rejects too (so
   callers can still `.catch()` it for logging), and `invalid`/`error` are set.
+- **isLoading**: `boolean` — `true` while `action` is being awaited inside
+  `submit()` (the OTP already passed the length check). Wire it to your
+  submit button's `loading`/`disabled` state. It stays `false` for the
+  too-short validation failure, since `action` isn't called in that case.
 - **secondsLeft**: `number` — seconds remaining until resend is available.
 - **restartCountdown**: `() => void` — restarts the resend countdown (call it
   from your "Resend" action).
@@ -57,7 +61,7 @@ import { useOtp, DInputPin, DButton, DAlert } from '@dynamic-framework/ui-react'
 
 export function ExampleOfUse() {
   const {
-    otp, setOtp, invalid, error, submit, secondsLeft, restartCountdown,
+    otp, setOtp, invalid, error, submit, isLoading, secondsLeft, restartCountdown,
   } = useOtp({
     // Simulates a backend call that rejects any code other than "1234".
     action: () => new Promise((resolve, reject) => {
@@ -90,7 +94,7 @@ export function ExampleOfUse() {
           disabled={secondsLeft > 0}
           onClick={restartCountdown}
         />
-        <DButton text="Verify" onClick={() => { submit().catch(() => {}); }} />
+        <DButton text="Verify" loading={isLoading} onClick={() => { submit().catch(() => {}); }} />
       </div>
     </div>
   );

--- a/stories/hooks/useOtpExamples.tsx
+++ b/stories/hooks/useOtpExamples.tsx
@@ -12,6 +12,7 @@ export function ExampleOfUse() {
     invalid,
     error,
     submit,
+    isLoading,
     secondsLeft,
     restartCountdown,
   } = useOtp({
@@ -54,6 +55,7 @@ export function ExampleOfUse() {
         />
         <DButton
           text="Verify"
+          loading={isLoading}
           onClick={() => {
             submit().catch(() => {});
           }}

--- a/stories/hooks/useOtpExamples.tsx
+++ b/stories/hooks/useOtpExamples.tsx
@@ -1,0 +1,68 @@
+import {
+  useOtp,
+  DInputPin,
+  DButton,
+  DAlert,
+} from '../../src';
+
+export function ExampleOfUse() {
+  const {
+    otp,
+    setOtp,
+    invalid,
+    error,
+    submit,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    // Simulates a backend call that rejects any code other than "1234".
+    action: () => new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (otp === '1234') {
+          resolve();
+        } else {
+          reject(new Error('The code you entered is incorrect.'));
+        }
+      }, 800);
+    }),
+    otpSize: 4,
+    seconds: 10,
+  });
+
+  return (
+    <div className="d-flex flex-column gap-3" style={{ maxWidth: 360 }}>
+      <h5 className="mb-0">Enter your verification code</h5>
+      <p className="small text-muted mb-0">Try &quot;1234&quot; for a successful submit.</p>
+      <DInputPin
+        characters={4}
+        onChange={setOtp}
+        invalid={invalid}
+        placeholder="•"
+      />
+      {invalid && (
+        <DAlert color="danger">
+          {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+        </DAlert>
+      )}
+      <div className="d-flex justify-content-between align-items-center">
+        <DButton
+          variant="link"
+          size="sm"
+          text={secondsLeft > 0 ? `Resend in ${secondsLeft}s` : 'Resend code'}
+          disabled={secondsLeft > 0}
+          onClick={restartCountdown}
+        />
+        <DButton
+          text="Verify"
+          onClick={() => {
+            submit().catch(() => {});
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ExampleRoot() {
+  return <ExampleOfUse />;
+}


### PR DESCRIPTION
## Resumen

Agrega un hook headless `useOtp` y promueve `useCountdown` a un hook público
e independiente, para que los devs puedan construir UIs de OTP totalmente
personalizadas reutilizando la misma lógica que ya implementa `DOtp`.

## Cambios

- **`useCountdown`** se movió de `src/components/DOtp/hooks/useCountdown.tsx`
  (privado) a `src/hooks/useCountdown.tsx` (público) y se exporta desde el
  índice de hooks. Es genérico y reutilizable más allá del OTP (timers de
  reenvío/cooldown/throttle).
- **Nuevo hook `useOtp`** (`src/hooks/useOtp.tsx`) que expone la misma lógica
  de OTP usada internamente por `DOtp` — estado del código, validación de
  longitud y de corrección, acción de envío, y countdown de reenvío — sin
  ningún markup/estilos incluidos.
  - Compone `useCountdown` internamente y re-expone
    `secondsLeft`/`restartCountdown`.
  - `submit()` trata como `invalid` tanto un código demasiado corto **como**
    un rechazo de `action()` (ej. el backend indica que el código es
    incorrecto), exponiendo el valor lanzado como `error` para que las UIs
    custom puedan mostrar el mensaje adecuado.
  - `invalid`/`error` se limpian automáticamente en cuanto el código se
    edita mediante `setOtp`.
- **`DOtp.tsx`** refactorizado para usar `useOtp` como única fuente de
  verdad. `OtpCountdown` ahora es puramente presentacional (recibe
  `secondsLeft`/`restartCountdown` como props en lugar de llamar a
  `useCountdown` por su cuenta), evitando dos timers corriendo de forma
  desincronizada. La API pública de `DOtp` no cambia, y se agregó un texto
  opcional `texts.invalidCode` mostrado cuando el código ingresado es
  inválido.
- Tests: `useCountdown.spec.ts`, `useOtp.spec.tsx`.
- Documentación en Storybook: `useCountdown.mdx`, `useOtp.mdx` (+ componentes
  de ejemplo), siguiendo el patrón de documentación del hook
  `useConfirmModal`.

## Pruebas realizadas

- `tsc -p ./tsconfig.build.json --noEmit` ✅
- `npm run eslint` (archivos afectados) ✅
- `npx jest` — suite completa pasando (540/540) ✅

🤖 Generado con [Copilot CLI](https://github.com/github/copilot-cli)
