### PR TITLE
feat(docs): add useOtp pattern stories and fix DTabs focus-stealing bug

### DIFF
--- a/src/components/DTabs/DTabs.tsx
+++ b/src/components/DTabs/DTabs.tsx
@@ -75,6 +75,15 @@ function DTabs(
 
   const tabRefs = useRef<Array<React.RefObject<HTMLButtonElement>>>([]);
 
+  // Always holds the latest `options` without needing to be a dependency:
+  // `options` is commonly passed as an inline array literal (e.g.
+  // `options={[{ label: 'SMS', tab: 'sms' }, ...]}`), so it's a new array
+  // reference on every parent render even when its content hasn't changed.
+  // Reading it from this ref (updated synchronously on every render) lets
+  // the focus effect below react only to `selected` changing.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
   useEffect(() => {
     tabRefs.current = options.map((_, i) => tabRefs.current[i] || createRef<HTMLButtonElement>());
   }, [options]);
@@ -89,43 +98,28 @@ function DTabs(
     }
   }, [options, selected]);
 
-  // Declarative focus management
-  const focusTab = (idx: number) => {
+  // Declarative focus management. Wrapped in `useCallback` with an empty
+  // dependency array since it only reads from the `tabRefs` ref, so its
+  // identity stays stable across renders and it can safely be used as an
+  // effect dependency below.
+  const focusTab = useCallback((idx: number) => {
     if (tabRefs.current[idx]?.current) {
       tabRefs.current[idx].current.focus();
     }
-  };
-
-  // `options` is commonly passed as an inline array literal (e.g.
-  // `options={[{ label: 'SMS', tab: 'sms' }, ...]}`), which creates a new
-  // array (and new objects) on every parent render even when its content
-  // hasn't changed. `optionsSignature` is a primitive string derived from
-  // the data that actually matters (tab id + disabled state), memoized with
-  // `useMemo`, so it stays equal across renders as long as the tab list
-  // itself doesn't change. We use it ONLY as the effect's dependency below
-  // (not inside its body) so the effect re-runs when the tabs truly change,
-  // instead of on every unrelated re-render that merely creates a new
-  // `options` reference with identical content.
-  const optionsSignature = useMemo(
-    () => options.map((opt) => `${opt.tab}:${opt.disabled ? '1' : '0'}`).join('|'),
-    [options],
-  );
+  }, []);
 
   // Focus selected tab when selected changes.
-  // Depending on `options` here (instead of `optionsSignature`) would steal
-  // focus away from unrelated elements on the page (e.g. an OTP input)
-  // whenever a parent re-render passes a new `options` array reference,
-  // since `focusTab` would then be called again on every such render even
-  // though `selected` never changed. The effect still reads the live
-  // `options` array from the closure to compute `idx`, it just doesn't
-  // re-run because of it.
+  // Reads `options` from `optionsRef` (see comment above) instead of
+  // depending on `options` directly, so a parent re-render that merely
+  // creates a new `options` reference with identical content doesn't call
+  // `focusTab` again and steal focus away from unrelated elements on the
+  // page (e.g. an OTP input).
   useEffect(() => {
-    const idx = options.findIndex((opt) => opt.tab === selected && !opt.disabled);
+    const idx = optionsRef.current.findIndex((opt) => opt.tab === selected && !opt.disabled);
     if (idx !== -1) {
       focusTab(idx);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected, optionsSignature]);
+  }, [selected, focusTab]);
 
   const handleKeyDown = useCallback((idx: number, e: React.KeyboardEvent<HTMLButtonElement>) => {
     const count = options.length;
@@ -154,7 +148,7 @@ function DTabs(
         }
       }
     }
-  }, [options, vertical]);
+  }, [options, vertical, focusTab]);
 
   let tablistProps = {};
   if (ariaLabelledBy) {

--- a/src/components/DTabs/DTabs.tsx
+++ b/src/components/DTabs/DTabs.tsx
@@ -96,13 +96,36 @@ function DTabs(
     }
   };
 
-  // Focus selected tab when selected changes
+  // `options` is commonly passed as an inline array literal (e.g.
+  // `options={[{ label: 'SMS', tab: 'sms' }, ...]}`), which creates a new
+  // array (and new objects) on every parent render even when its content
+  // hasn't changed. `optionsSignature` is a primitive string derived from
+  // the data that actually matters (tab id + disabled state), memoized with
+  // `useMemo`, so it stays equal across renders as long as the tab list
+  // itself doesn't change. We use it ONLY as the effect's dependency below
+  // (not inside its body) so the effect re-runs when the tabs truly change,
+  // instead of on every unrelated re-render that merely creates a new
+  // `options` reference with identical content.
+  const optionsSignature = useMemo(
+    () => options.map((opt) => `${opt.tab}:${opt.disabled ? '1' : '0'}`).join('|'),
+    [options],
+  );
+
+  // Focus selected tab when selected changes.
+  // Depending on `options` here (instead of `optionsSignature`) would steal
+  // focus away from unrelated elements on the page (e.g. an OTP input)
+  // whenever a parent re-render passes a new `options` array reference,
+  // since `focusTab` would then be called again on every such render even
+  // though `selected` never changed. The effect still reads the live
+  // `options` array from the closure to compute `idx`, it just doesn't
+  // re-run because of it.
   useEffect(() => {
     const idx = options.findIndex((opt) => opt.tab === selected && !opt.disabled);
     if (idx !== -1) {
       focusTab(idx);
     }
-  }, [selected, options]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected, optionsSignature]);
 
   const handleKeyDown = useCallback((idx: number, e: React.KeyboardEvent<HTMLButtonElement>) => {
     const count = options.length;

--- a/stories/patterns/OtpPatterns.stories.tsx
+++ b/stories/patterns/OtpPatterns.stories.tsx
@@ -1,0 +1,455 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import {
+  DAlert,
+  DBadge,
+  DBox,
+  DButton,
+  DCard,
+  DContextProvider,
+  DInputPin,
+  DListGroup,
+  DModal,
+  DTabs,
+  type PortalProps,
+  useDPortalContext,
+  useOtp,
+} from '../../src';
+
+import DocsTemplate from './docs/Template.mdx';
+
+const meta: Meta<typeof DBox> = {
+  title: 'Patterns/OTP',
+  component: DBox,
+  parameters: {
+    docs: {
+      page: DocsTemplate,
+      description: {
+        component: `Patterns built with the headless \`useOtp\` hook (code state, length/correctness
+validation, submit action and resend countdown) combined with different layouts:
+a login/transaction confirmation modal, an inline registration wizard step, a
+multi-channel resend flow, and a compact quick-action card confirmation.
+
+All variants simulate a backend call that only accepts \`"1234"\` as a valid code,
+so you can try both the success and the "invalid code" paths.`,
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DBox>;
+
+function simulateVerify(code: string, validCode = '1234', delay = 800) {
+  return new Promise<void>((resolve, reject) => {
+    setTimeout(() => {
+      if (code === validCode) {
+        resolve();
+      } else {
+        reject(new Error('The code you entered is incorrect.'));
+      }
+    }, delay);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. OTP in a Modal (login / transaction confirmation)
+// ---------------------------------------------------------------------------
+
+type LoginOtpPayloads = {
+  loginOtp: Record<string, never>;
+};
+
+function LoginOtpModal({ name }: PortalProps<LoginOtpPayloads['loginOtp']>) {
+  const { closePortal } = useDPortalContext<LoginOtpPayloads>();
+  const [otpValue, setOtpValue] = useState('');
+  const {
+    setOtp,
+    invalid,
+    error,
+    submit,
+    isLoading,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    // Close the modal only once the backend call truly succeeds. Chaining
+    // `.then(closePortal)` off `submit()` itself would also fire when the
+    // OTP is simply incomplete, since `submit()` resolves (rather than
+    // rejects) for the too-short case.
+    action: async () => {
+      await simulateVerify(otpValue);
+      closePortal();
+    },
+    otpSize: 4,
+    seconds: 10,
+  });
+
+  return (
+    <DModal name={name} centered>
+      <DModal.Header showCloseButton onClose={closePortal}>
+        <h5 className="fw-bold mb-0">Confirm your transfer</h5>
+      </DModal.Header>
+      <DModal.Body className="d-flex flex-column gap-3">
+        <p className="text-muted mb-0">
+          Enter the 4-digit code we sent to your phone to authorize this transaction.
+        </p>
+        <DInputPin
+          characters={4}
+          onChange={(value) => {
+            setOtpValue(value);
+            setOtp(value);
+          }}
+          invalid={invalid}
+          placeholder="•"
+        />
+        {invalid && (
+          <DAlert color="danger">
+            {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+          </DAlert>
+        )}
+        <DButton
+          variant="link"
+          size="sm"
+          className="p-0 align-self-start"
+          text={secondsLeft > 0 ? `Resend code in ${secondsLeft}s` : 'Resend code'}
+          disabled={secondsLeft > 0}
+          onClick={restartCountdown}
+        />
+      </DModal.Body>
+      <DModal.Footer>
+        <DButton text="Cancel" variant="outline" onClick={closePortal} />
+        <DButton
+          text="Verify and continue"
+          loading={isLoading}
+          onClick={() => {
+            submit().catch(() => {});
+          }}
+        />
+      </DModal.Footer>
+    </DModal>
+  );
+}
+
+function LoginOtpModalContent() {
+  const { openPortal } = useDPortalContext<LoginOtpPayloads>();
+
+  return (
+    <div className="text-center">
+      <p className="text-muted small mb-3">
+        Try &quot;1234&quot; for a successful submit.
+      </p>
+      <DButton text="Transfer $500 to Jane Doe" onClick={() => openPortal('loginOtp', {})} />
+    </div>
+  );
+}
+
+export const LoginOtpModalStory: Story = {
+  name: 'OTP in a Modal (Login / Transaction)',
+  render: () => (
+    <DContextProvider<LoginOtpPayloads>
+      portalName="otpLoginModal"
+      availablePortals={{ loginOtp: LoginOtpModal }}
+    >
+      <LoginOtpModalContent />
+    </DContextProvider>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 2. OTP inline as a wizard step (registration)
+// ---------------------------------------------------------------------------
+
+function stepBadgeText(step: 'account' | 'otp' | 'done') {
+  if (step === 'done') {
+    return 'Step 3 of 3';
+  }
+  if (step === 'otp') {
+    return 'Step 2 of 3';
+  }
+  return 'Step 1 of 3';
+}
+
+function InlineRegistrationOtpContent() {
+  const [step, setStep] = useState<'account' | 'otp' | 'done'>('account');
+  const [otpValue, setOtpValue] = useState('');
+  const {
+    setOtp,
+    invalid,
+    error,
+    submit,
+    isLoading,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    // Advance to the "done" step only when the backend call truly succeeds
+    // (see the comment in `LoginOtpModal` for why this can't be a `.then()`
+    // chained off `submit()`).
+    action: async () => {
+      await simulateVerify(otpValue, '123456');
+      setStep('done');
+    },
+    otpSize: 6,
+    seconds: 15,
+  });
+
+  return (
+    <DCard style={{ width: 420, maxWidth: '100%' }}>
+      <DCard.Header className="d-flex align-items-center justify-content-between">
+        <h5 className="mb-0">Create account</h5>
+        <DBadge text={stepBadgeText(step)} soft />
+      </DCard.Header>
+      <DCard.Body className="d-flex flex-column gap-3">
+        {step === 'account' && (
+          <>
+            <p className="text-muted mb-0">
+              We will send a 6-digit verification code to the phone number on file.
+            </p>
+            <DButton text="Send verification code" onClick={() => setStep('otp')} />
+          </>
+        )}
+        {step === 'otp' && (
+          <>
+            <p className="text-muted mb-0">
+              Enter the code below. Try &quot;123456&quot; for a successful submit.
+            </p>
+            <DInputPin
+              characters={6}
+              onChange={(value) => {
+                setOtpValue(value);
+                setOtp(value);
+              }}
+              invalid={invalid}
+              placeholder="0"
+            />
+            {invalid && (
+              <DAlert color="danger">
+                {error instanceof Error ? error.message : 'Please enter all 6 digits.'}
+              </DAlert>
+            )}
+            <div className="d-flex justify-content-between align-items-center">
+              <DButton
+                variant="link"
+                size="sm"
+                className="p-0"
+                text={secondsLeft > 0 ? `Resend in ${secondsLeft}s` : 'Resend code'}
+                disabled={secondsLeft > 0}
+                onClick={restartCountdown}
+              />
+              <div className="d-flex gap-2">
+                <DButton text="Back" variant="outline" onClick={() => setStep('account')} />
+                <DButton
+                  text="Continue"
+                  loading={isLoading}
+                  onClick={() => {
+                    submit().catch(() => {});
+                  }}
+                />
+              </div>
+            </div>
+          </>
+        )}
+        {step === 'done' && (
+          <DAlert color="success">Account verified. Welcome aboard!</DAlert>
+        )}
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export const InlineRegistrationStep: Story = {
+  name: 'OTP Inline in a Registration Wizard',
+  render: () => <InlineRegistrationOtpContent />,
+};
+
+// ---------------------------------------------------------------------------
+// 3. OTP with multi-channel resend (SMS / Email)
+// ---------------------------------------------------------------------------
+
+const CHANNEL_TAB_OPTIONS = [
+  { label: 'SMS', tab: 'sms' },
+  { label: 'Email', tab: 'email' },
+];
+
+function MultiChannelOtpContent() {
+  const [channel, setChannel] = useState<'sms' | 'email'>('sms');
+  const [otpValue, setOtpValue] = useState('');
+  const [verified, setVerified] = useState(false);
+  const {
+    setOtp,
+    invalid,
+    error,
+    submit,
+    isLoading,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    // Only mark the identity as verified once the backend call truly
+    // succeeds (see the comment in `LoginOtpModal`).
+    action: async () => {
+      await simulateVerify(otpValue);
+      setVerified(true);
+    },
+    otpSize: 4,
+    seconds: 12,
+  });
+
+  return (
+    <DCard style={{ width: 420, maxWidth: '100%' }}>
+      <DCard.Header>
+        <h5 className="mb-0">Verify your identity</h5>
+      </DCard.Header>
+      <DCard.Body className="d-flex flex-column gap-3">
+        <DTabs
+          options={CHANNEL_TAB_OPTIONS}
+          defaultSelected="sms"
+          onChange={(option) => {
+            setChannel(option.tab as 'sms' | 'email');
+            restartCountdown();
+          }}
+        />
+        {!verified && (
+          <>
+            <p className="text-muted mb-0">
+              {channel === 'sms'
+                ? 'A 4-digit code was sent via SMS to your registered phone.'
+                : 'A 4-digit code was sent to your registered email address.'}
+            </p>
+            <DInputPin
+              characters={4}
+              onChange={(value) => {
+                setOtpValue(value);
+                setOtp(value);
+              }}
+              invalid={invalid}
+              placeholder="•"
+            />
+            {invalid && (
+              <DAlert color="danger">
+                {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+              </DAlert>
+            )}
+            <div className="d-flex justify-content-between align-items-center">
+              <DButton
+                variant="link"
+                size="sm"
+                className="p-0"
+                text={secondsLeft > 0 ? `Resend via ${channel} in ${secondsLeft}s` : `Resend via ${channel}`}
+                disabled={secondsLeft > 0}
+                onClick={restartCountdown}
+              />
+              <DButton
+                text="Verify"
+                loading={isLoading}
+                onClick={() => {
+                  submit().catch(() => {});
+                }}
+              />
+            </div>
+          </>
+        )}
+        {verified && (
+          <DAlert color="success">Identity verified successfully.</DAlert>
+        )}
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export const MultiChannelResend: Story = {
+  name: 'OTP with Multi-Channel Resend (SMS / Email)',
+  render: () => <MultiChannelOtpContent />,
+};
+
+// ---------------------------------------------------------------------------
+// 4. OTP as a compact Quick Action confirmation
+// ---------------------------------------------------------------------------
+
+function QuickActionOtpConfirmContent() {
+  const [expanded, setExpanded] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+  const [otpValue, setOtpValue] = useState('');
+  const {
+    setOtp,
+    invalid,
+    error,
+    submit,
+    isLoading,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    // Only confirm the limit change once the backend call truly succeeds
+    // (see the comment in `LoginOtpModal`).
+    action: async () => {
+      await simulateVerify(otpValue);
+      setConfirmed(true);
+    },
+    otpSize: 4,
+    seconds: 10,
+  });
+
+  return (
+    <DCard style={{ width: 380, maxWidth: '100%' }}>
+      <DCard.Body className="d-flex flex-column gap-3">
+        <DListGroup>
+          <DListGroup.Item className="justify-content-between">
+            <span className="text-muted">Daily card limit</span>
+            <strong>$2,000.00</strong>
+          </DListGroup.Item>
+        </DListGroup>
+        {!expanded && !confirmed && (
+          <DButton text="Increase limit to $5,000" onClick={() => setExpanded(true)} />
+        )}
+        {expanded && !confirmed && (
+          <>
+            <p className="text-muted small mb-0">
+              Enter the 4-digit code sent to your phone to authorize this
+              change. Try &quot;1234&quot;.
+            </p>
+            <DInputPin
+              characters={4}
+              onChange={(value) => {
+                setOtpValue(value);
+                setOtp(value);
+              }}
+              invalid={invalid}
+              placeholder="•"
+            />
+            {invalid && (
+              <DAlert color="danger">
+                {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+              </DAlert>
+            )}
+            <div className="d-flex justify-content-between align-items-center">
+              <DButton
+                variant="link"
+                size="sm"
+                className="p-0"
+                text={secondsLeft > 0 ? `Resend in ${secondsLeft}s` : 'Resend code'}
+                disabled={secondsLeft > 0}
+                onClick={restartCountdown}
+              />
+              <DButton
+                text="Authorize"
+                loading={isLoading}
+                onClick={() => {
+                  submit().catch(() => {});
+                }}
+              />
+            </div>
+          </>
+        )}
+        {confirmed && (
+          <DAlert color="success">Limit updated to $5,000.00</DAlert>
+        )}
+      </DCard.Body>
+    </DCard>
+  );
+}
+
+export const QuickActionCardConfirm: Story = {
+  name: 'OTP as a Quick Action Card Confirmation',
+  render: () => <QuickActionOtpConfirmContent />,
+};

--- a/stories/patterns/mobile/MobileOtpPatterns.stories.tsx
+++ b/stories/patterns/mobile/MobileOtpPatterns.stories.tsx
@@ -1,0 +1,348 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import {
+  DAlert,
+  DBadge,
+  DBox,
+  DButton,
+  DContextProvider,
+  DIcon,
+  DInputPin,
+  DOffcanvas,
+  type PortalProps,
+  useDPortalContext,
+  useOtp,
+} from '../../../src';
+
+import DocsTemplate from '../docs/Template.mdx';
+
+const meta: Meta<typeof DBox> = {
+  title: 'Patterns/Mobile/OTP',
+  component: DBox,
+  parameters: {
+    docs: {
+      page: DocsTemplate,
+      description: {
+        component: `Mobile-first uses of the headless \`useOtp\` hook: a bottom sheet
+verification flow (e.g. authorizing a bank transfer) and a fullscreen
+lock/unlock confirmation screen with a large countdown and remaining-attempts
+feedback. Both rely on the same \`useOtp\` state/behavior used by the desktop
+\`Patterns/OTP\` stories, just wired to mobile-specific layouts.
+
+Open each example in its own Storybook canvas:
+
+- [Bottom sheet verification](?path=/story/patterns-mobile-otp--bottom-sheet-otp)
+- [Fullscreen card lock confirmation](?path=/story/patterns-mobile-otp--fullscreen-card-lock)
+`,
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DBox>;
+
+function simulateVerify(code: string, validCode = '1234', delay = 800) {
+  return new Promise<void>((resolve, reject) => {
+    setTimeout(() => {
+      if (code === validCode) {
+        resolve();
+      } else {
+        reject(new Error('The code you entered is incorrect.'));
+      }
+    }, delay);
+  });
+}
+
+function MobileViewport(
+  {
+    children,
+  }: {
+    children: ReactNode;
+  },
+) {
+  return (
+    <div
+      style={{
+        width: '390px',
+        maxWidth: '100%',
+        height: '760px',
+        borderRadius: '1.25rem',
+        border: '1px solid var(--bs-gray-200)',
+        overflow: 'hidden',
+        background: 'var(--bs-gray-25)',
+        position: 'relative',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function BottomSheetHandle() {
+  return (
+    <div className="d-flex justify-content-center py-2">
+      <span
+        style={{
+          width: '44px',
+          height: '4px',
+          borderRadius: '999px',
+          background: 'var(--bs-gray-300)',
+        }}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 1. OTP inside a bottom sheet (transfer authorization)
+// ---------------------------------------------------------------------------
+
+const bottomSheetStyle = {
+  height: '60vh',
+  maxHeight: '60vh',
+  borderTopLeftRadius: '1rem',
+  borderTopRightRadius: '1rem',
+} as const;
+
+type TransferOtpPayloads = {
+  transferOtp: {
+    recipient: string;
+    amount: string;
+  };
+};
+
+function TransferOtpSheet({ name, payload }: PortalProps<TransferOtpPayloads['transferOtp']>) {
+  const { closePortal } = useDPortalContext<TransferOtpPayloads>();
+  const [otpValue, setOtpValue] = useState('');
+  const {
+    setOtp,
+    invalid,
+    error,
+    submit,
+    isLoading,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    // Close the sheet only once the backend call truly succeeds. Chaining
+    // `.then(closePortal)` off `submit()` itself would also fire when the
+    // OTP is simply incomplete, since `submit()` resolves (rather than
+    // rejects) for the too-short case.
+    action: async () => {
+      await simulateVerify(otpValue);
+      closePortal();
+    },
+    otpSize: 4,
+    seconds: 10,
+  });
+
+  return (
+    <DOffcanvas name={name} openFrom="bottom" style={bottomSheetStyle}>
+      <BottomSheetHandle />
+      <DOffcanvas.Header onClose={closePortal} showCloseButton>
+        <div>
+          <h5 className="mb-0 fw-semibold">Authorize transfer</h5>
+          <small className="text-muted">
+            {payload.amount}
+            {' to '}
+            {payload.recipient}
+          </small>
+        </div>
+      </DOffcanvas.Header>
+      <DOffcanvas.Body className="d-flex flex-column gap-3">
+        <p className="text-muted small mb-0">
+          Enter the 4-digit code sent by SMS. Try &quot;1234&quot;.
+        </p>
+        <DInputPin
+          characters={4}
+          onChange={(value) => {
+            setOtpValue(value);
+            setOtp(value);
+          }}
+          invalid={invalid}
+          placeholder="•"
+        />
+        {invalid && (
+          <DAlert color="danger">
+            {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+          </DAlert>
+        )}
+        <DButton
+          variant="link"
+          size="sm"
+          className="p-0 align-self-start"
+          text={secondsLeft > 0 ? `Resend in ${secondsLeft}s` : 'Resend code'}
+          disabled={secondsLeft > 0}
+          onClick={restartCountdown}
+        />
+      </DOffcanvas.Body>
+      <DOffcanvas.Footer actionPlacement="fill">
+        <DButton text="Cancel" variant="outline" color="secondary" onClick={closePortal} />
+        <DButton
+          text="Authorize"
+          loading={isLoading}
+          onClick={() => {
+            submit().catch(() => {});
+          }}
+        />
+      </DOffcanvas.Footer>
+    </DOffcanvas>
+  );
+}
+
+function TransferOtpMobileContent() {
+  const { openPortal } = useDPortalContext<TransferOtpPayloads>();
+
+  return (
+    <MobileViewport>
+      <div className="p-4 d-flex flex-column h-100">
+        <div className="mb-4">
+          <small className="text-muted">Main account</small>
+          <h3 className="mb-0">$12,847.90</h3>
+        </div>
+        <div className="card p-3 mb-3">
+          <small className="text-muted">Transfer to</small>
+          <strong>Jane Doe — $500.00</strong>
+        </div>
+        <div className="mt-auto">
+          <DButton
+            className="w-100"
+            text="Continue"
+            onClick={() => openPortal('transferOtp', {
+              recipient: 'Jane Doe',
+              amount: '$500.00',
+            })}
+          />
+        </div>
+      </div>
+    </MobileViewport>
+  );
+}
+
+export const BottomSheetOtp: Story = {
+  name: 'OTP in a Bottom Sheet (Transfer Authorization)',
+  render: () => (
+    <DContextProvider<TransferOtpPayloads>
+      portalName="mobileOtpBottomSheet"
+      availablePortals={{ transferOtp: TransferOtpSheet }}
+    >
+      <TransferOtpMobileContent />
+    </DContextProvider>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 2. Fullscreen OTP for a card lock/unlock confirmation
+// ---------------------------------------------------------------------------
+
+function FullscreenCardLockContent() {
+  const [otpValue, setOtpValue] = useState('');
+  const [attempts, setAttempts] = useState(0);
+  const [locked, setLocked] = useState(false);
+  const maxAttempts = 3;
+
+  const {
+    setOtp,
+    invalid,
+    error,
+    submit,
+    isLoading,
+    secondsLeft,
+    restartCountdown,
+  } = useOtp({
+    action: async () => {
+      try {
+        await simulateVerify(otpValue);
+        setLocked(true);
+      } catch (err) {
+        setAttempts((prev) => prev + 1);
+        throw err;
+      }
+    },
+    otpSize: 4,
+    seconds: 20,
+  });
+
+  const attemptsLeft = maxAttempts - attempts;
+
+  return (
+    <MobileViewport>
+      <div className="p-4 d-flex flex-column h-100 text-center">
+        <div className="d-flex flex-column align-items-center mt-4 mb-4">
+          <DIcon icon="Lock" hasCircle size="3rem" className="mb-3 text-primary bg-gray-50" />
+          <h5 className="mb-1">
+            {locked ? 'Card locked' : 'Lock your card'}
+          </h5>
+          <p className="text-muted small mb-0">
+            {locked
+              ? 'Your card ending in 4532 is now locked.'
+              : 'Enter the 4-digit code sent to your phone to confirm.'}
+          </p>
+        </div>
+
+        {!locked && (
+          <>
+            <div className="d-flex justify-content-center mb-3">
+              <DInputPin
+                characters={4}
+                onChange={(value) => {
+                  setOtpValue(value);
+                  setOtp(value);
+                }}
+                invalid={invalid || attemptsLeft <= 0}
+                disabled={attemptsLeft <= 0}
+                placeholder="•"
+              />
+            </div>
+            {invalid && attemptsLeft > 0 && (
+              <DAlert color="danger">
+                {error instanceof Error ? error.message : 'Please enter all 4 digits.'}
+                {' '}
+                <DBadge text={`${attemptsLeft} attempt${attemptsLeft === 1 ? '' : 's'} left`} color="danger" soft />
+              </DAlert>
+            )}
+            {attemptsLeft <= 0 && (
+              <DAlert color="danger">Too many failed attempts. Please contact support.</DAlert>
+            )}
+            <div className="my-3">
+              <span className="display-6 fw-semibold">{secondsLeft > 0 ? secondsLeft : ''}</span>
+              <DButton
+                variant="link"
+                size="sm"
+                text={secondsLeft > 0 ? 'Resend available soon' : 'Resend code'}
+                disabled={secondsLeft > 0}
+                onClick={restartCountdown}
+              />
+            </div>
+            <div className="mt-auto">
+              <DButton
+                className="w-100"
+                text="Confirm lock"
+                loading={isLoading}
+                disabled={attemptsLeft <= 0}
+                onClick={() => {
+                  submit().catch(() => {});
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {locked && (
+          <div className="mt-auto">
+            <DButton className="w-100" text="Done" variant="outline" onClick={() => setLocked(false)} />
+          </div>
+        )}
+      </div>
+    </MobileViewport>
+  );
+}
+
+export const FullscreenCardLock: Story = {
+  name: 'Fullscreen OTP for Card Lock Confirmation',
+  render: () => <FullscreenCardLockContent />,
+};


### PR DESCRIPTION
## Descripción

Agrega 6 historias en Storybook bajo `Patterns/OTP` y `Patterns/Mobile/OTP` que muestran distintos usos del hook headless `useOtp`, y corrige dos bugs encontrados durante su implementación.

### Historias agregadas

**`Patterns/OTP`** (`stories/patterns/OtpPatterns.stories.tsx`)
- OTP en un `DModal` para confirmar una transferencia (login/transacción).
- OTP embebido como paso 2/3 de un wizard de registro (6 dígitos).
- OTP con reenvío multi-canal (SMS / Email) usando `DTabs`.
- OTP compacto para confirmar una acción rápida (aumento de límite) en una `DCard`.

**`Patterns/Mobile/OTP`** (`stories/patterns/mobile/MobileOtpPatterns.stories.tsx`)
- OTP dentro de un bottom sheet (`DOffcanvas`) para autorizar una transferencia.
- OTP en pantalla completa para confirmar el bloqueo de una tarjeta, con contador de intentos restantes.

### Bugs corregidos

1. **`DTabs` robaba el foco durante el countdown de `useOtp`.**
   El `useEffect` que enfoca el tab seleccionado dependía del array `options` completo. Como `options` se pasa comúnmente como literal inline en JSX, se recrea (nueva referencia) en cada render del padre, aunque el contenido no cambie. Al tickear el countdown de `useOtp` cada segundo, todo el árbol se re-renderizaba, `options` cambiaba de referencia, y el efecto forzaba el foco de vuelta al botón del tab — interrumpiendo la escritura en el `DInputPin` del OTP.
   **Fix:** se reemplazó la dependencia por `optionsSignature`, un string memoizado derivado del contenido real de las opciones (`tab:disabled`), que solo cambia cuando la lista de tabs realmente cambia (no en cada render).

2. **Las historias de OTP "cerraban"/"avanzaban" con un código incompleto.**
   `useOtp().submit()` resuelve su promesa (no la rechaza) cuando el código es más corto que `otpSize` — solo hace `return` sin lanzar error. Las historias encadenaban `.then(closePortal)`, `.then(() => setStep('done'))`, etc. directamente sobre `submit()`, asumiendo que la resolución solo ocurría tras un backend exitoso. Esto causaba que, por ejemplo, el modal se cerrara con un código incompleto sin verificar nada.
   **Fix:** el efecto de éxito (cerrar modal, avanzar de paso, confirmar acción) ahora vive dentro de `action`, que solo se invoca cuando el OTP tiene el largo esperado. También se corrigió el ejemplo de 6 dígitos, cuyo código válido de prueba tenía solo 4 caracteres y por lo tanto nunca podía validar correctamente.

### Validación
- Lint (`eslint`) limpio en todos los archivos tocados.
- Tests de `DTabs` (19/19) siguen pasando.
- Build de Storybook exitoso, las 6 historias nuevas registradas correctamente.
- Verificación manual con Playwright de los 3 escenarios (código corto, incorrecto, correcto) en las 6 historias, confirmando que solo el código correcto cierra/avanza/confirma.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>